### PR TITLE
Limit Supabase CORS to env domain list

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ This project is built with:
 
 Simply open [Lovable](https://lovable.dev/projects/13606cdc-6b16-461d-b2be-0098b12e8f3a) and click on Share -> Publish.
 
+When deploying the Supabase functions, set the `CORS_ALLOWED_ORIGINS` environment
+variable with a comma-separated list of domains allowed to call the functions.
+Only requests from these origins will be permitted.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/supabase/functions/retell-ai/index.ts
+++ b/supabase/functions/retell-ai/index.ts
@@ -2,10 +2,11 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 
-const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-}
+// Allowed origins can be configured via env, comma separated
+const allowedOrigins = (Deno.env.get('CORS_ALLOWED_ORIGINS') ?? '')
+  .split(',')
+  .map((o) => o.trim())
+  .filter(Boolean)
 
 interface RetellCallRequest {
   phoneNumber: string
@@ -24,6 +25,14 @@ interface RetellWebhookEvent {
 }
 
 serve(async (req) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin':
+      allowedOrigins.includes(req.headers.get('origin') ?? '')
+        ? req.headers.get('origin') ?? ''
+        : allowedOrigins[0] ?? '',
+    'Access-Control-Allow-Headers':
+      'authorization, x-client-info, apikey, content-type',
+  }
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders })
   }


### PR DESCRIPTION
## Summary
- restrict `ai-agent` and `retell-ai` functions to origins in `CORS_ALLOWED_ORIGINS`
- document the new environment variable in the deployment section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68411ae8d19c8328ad74e7b52685df71