### PR TITLE
Update dashboard routes

### DIFF
--- a/src/components/Dashboard/DashboardNavigation.tsx
+++ b/src/components/Dashboard/DashboardNavigation.tsx
@@ -12,7 +12,7 @@ const DashboardNavigation = () => {
   const { profile } = useAuth();
 
   const navItems = [
-    { label: 'Dashboard', href: '/sales-rep-dashboard', icon: Grid },
+    { label: 'Dashboard', href: '/sales/dashboard', icon: Grid },
     { label: 'Leads', href: '/leads', icon: Users },
     { label: 'Statistics', href: '/analytics', icon: BarChart3 },
     { label: 'Rep Dev', href: '/company-brain', icon: GraduationCap },
@@ -31,8 +31,8 @@ const DashboardNavigation = () => {
         <nav className="hidden md:flex items-center space-x-8">
           {navItems.map((item) => {
             const IconComponent = item.icon;
-            const isActive = location.pathname === item.href || 
-                           (item.href === '/sales-rep-dashboard' && location.pathname === '/');
+            const isActive = location.pathname === item.href ||
+                           (item.href === '/sales/dashboard' && location.pathname === '/');
             
             return (
               <Link

--- a/src/components/DashboardRouter.tsx
+++ b/src/components/DashboardRouter.tsx
@@ -21,7 +21,7 @@ const DashboardRouter = () => {
       case 'sales-rep':
         return <Navigate to="/" replace />;
       case 'manager':
-        return <Navigate to="/manager-dashboard" replace />;
+        return <Navigate to="/manager/dashboard" replace />;
       case 'admin':
         return <Navigate to="/admin-dashboard" replace />;
       default:
@@ -34,7 +34,7 @@ const DashboardRouter = () => {
   
   switch (role) {
     case 'manager':
-      return <Navigate to="/manager-dashboard" replace />;
+      return <Navigate to="/manager/dashboard" replace />;
     case 'admin':
       return <Navigate to="/admin-dashboard" replace />;
     case 'sales_rep':

--- a/src/components/DeveloperMode/RoleToggle.tsx
+++ b/src/components/DeveloperMode/RoleToggle.tsx
@@ -26,7 +26,7 @@ const RoleToggle: React.FC = () => {
       toast.success(`Switched to ${newRole.replace('_', ' ')} role`);
 
       // Redirect to appropriate dashboard
-      const redirectPath = newRole === 'manager' ? '/manager-dashboard' : '/sales-rep-dashboard';
+      const redirectPath = newRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
       window.location.href = redirectPath;
     } catch (error) {
       console.error('Error toggling role:', error);

--- a/src/components/Navigation/navigationUtils.ts
+++ b/src/components/Navigation/navigationUtils.ts
@@ -2,16 +2,16 @@
 import { Profile } from '@/contexts/auth/types';
 
 export const getDashboardUrl = (profile: Profile | null): string => {
-  if (!profile) return '/sales-rep-dashboard';
+  if (!profile) return '/sales/dashboard';
   
   switch (profile.role) {
     case 'admin':
       return '/admin-dashboard';
     case 'manager':
-      return '/manager-dashboard';
+      return '/manager/dashboard';
     case 'sales_rep':
     default:
-      return '/sales-rep-dashboard';
+      return '/sales/dashboard';
   }
 };
 

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -36,7 +36,7 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
     setIsTransitioning(true);
     
     // Direct navigation based on role - using correct existing routes
-    const redirectPath = selectedRole === 'manager' ? '/manager-dashboard' : '/sales-rep-dashboard';
+    const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
     console.log("Redirecting to:", redirectPath);
     
     setTimeout(() => {

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -109,10 +109,10 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
             navigate('/onboarding');
           } else {
             // Regular navigation based on role
-            navigate('/sales-rep-dashboard');
+            navigate('/sales/dashboard');
           }
         } else {
-          navigate('/sales-rep-dashboard');
+          navigate('/sales/dashboard');
         }
       }, 1500);
       


### PR DESCRIPTION
## Summary
- redirect manager dashboard to `/manager/dashboard`
- redirect sales dashboard to `/sales/dashboard`
- update navigation helpers and demo options for new routes

## Testing
- `npm run lint` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68411c923c0c83288a829027580bb4c6