### PR TITLE
Update dashboard redirect helper

### DIFF
--- a/src/components/Dashboard/DashboardNavigation.tsx
+++ b/src/components/Dashboard/DashboardNavigation.tsx
@@ -12,7 +12,7 @@ const DashboardNavigation = () => {
   const { profile } = useAuth();
 
   const navItems = [
-    { label: 'Dashboard', href: '/sales-rep-dashboard', icon: Grid },
+    { label: 'Dashboard', href: '/sales/dashboard', icon: Grid },
     { label: 'Leads', href: '/leads', icon: Users },
     { label: 'Statistics', href: '/analytics', icon: BarChart3 },
     { label: 'Rep Dev', href: '/company-brain', icon: GraduationCap },
@@ -31,8 +31,9 @@ const DashboardNavigation = () => {
         <nav className="hidden md:flex items-center space-x-8">
           {navItems.map((item) => {
             const IconComponent = item.icon;
-            const isActive = location.pathname === item.href || 
-                           (item.href === '/sales-rep-dashboard' && location.pathname === '/');
+            const isActive =
+              location.pathname === item.href ||
+              (item.href === '/sales/dashboard' && location.pathname === '/');
             
             return (
               <Link

--- a/src/components/DashboardRouter.tsx
+++ b/src/components/DashboardRouter.tsx
@@ -21,9 +21,9 @@ const DashboardRouter = () => {
       case 'sales-rep':
         return <Navigate to="/" replace />;
       case 'manager':
-        return <Navigate to="/manager-dashboard" replace />;
+        return <Navigate to="/manager/dashboard" replace />;
       case 'admin':
-        return <Navigate to="/admin-dashboard" replace />;
+        return <Navigate to="/sales/dashboard" replace />;
       default:
         return <Navigate to="/" replace />;
     }
@@ -34,12 +34,9 @@ const DashboardRouter = () => {
   
   switch (role) {
     case 'manager':
-      return <Navigate to="/manager-dashboard" replace />;
-    case 'admin':
-      return <Navigate to="/admin-dashboard" replace />;
-    case 'sales_rep':
+      return <Navigate to="/manager/dashboard" replace />;
     default:
-      return <Navigate to="/" replace />;
+      return <Navigate to="/sales/dashboard" replace />;
   }
 };
 

--- a/src/components/DeveloperMode/RoleToggle.tsx
+++ b/src/components/DeveloperMode/RoleToggle.tsx
@@ -5,6 +5,8 @@ import { Badge } from '@/components/ui/badge';
 import { Crown, User, Settings } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
+import { Profile } from '@/contexts/auth/types';
 const RoleToggle: React.FC = () => {
   const {
     user,
@@ -26,7 +28,7 @@ const RoleToggle: React.FC = () => {
       toast.success(`Switched to ${newRole.replace('_', ' ')} role`);
 
       // Redirect to appropriate dashboard
-      const redirectPath = newRole === 'manager' ? '/manager-dashboard' : '/sales-rep-dashboard';
+      const redirectPath = getDashboardUrl({ role: newRole } as Profile);
       window.location.href = redirectPath;
     } catch (error) {
       console.error('Error toggling role:', error);

--- a/src/components/Navigation/navigationUtils.ts
+++ b/src/components/Navigation/navigationUtils.ts
@@ -2,17 +2,9 @@
 import { Profile } from '@/contexts/auth/types';
 
 export const getDashboardUrl = (profile: Profile | null): string => {
-  if (!profile) return '/sales-rep-dashboard';
-  
-  switch (profile.role) {
-    case 'admin':
-      return '/admin-dashboard';
-    case 'manager':
-      return '/manager-dashboard';
-    case 'sales_rep':
-    default:
-      return '/sales-rep-dashboard';
-  }
+  if (!profile) return '/sales/dashboard';
+
+  return profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
 };
 
 export const updateActiveItem = (pathname: string, setActiveItem: (item: string) => void) => {

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,6 +2,8 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
+import { Profile } from '@/contexts/auth/types';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -31,23 +33,22 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
   // Role-based redirect logic
   if (roleBasedRedirect && profile?.role) {
     const currentPath = window.location.pathname;
-    
+    const dashboardUrl = getDashboardUrl(profile as Profile);
+
     if (profile.role === 'manager' && !currentPath.startsWith('/manager')) {
-      return <Navigate to="/manager/dashboard" replace />;
+      return <Navigate to={dashboardUrl} replace />;
     }
-    
+
     if (profile.role === 'sales_rep' && !currentPath.startsWith('/sales')) {
-      return <Navigate to="/sales/dashboard" replace />;
+      return <Navigate to={dashboardUrl} replace />;
     }
   }
 
   // Role requirement check
   if (requiredRole && profile?.role !== requiredRole) {
     // Redirect to appropriate dashboard based on role
-    if (profile?.role === 'manager') {
-      return <Navigate to="/manager/dashboard" replace />;
-    }
-    return <Navigate to="/sales/dashboard" replace />;
+    const dashboardUrl = getDashboardUrl(profile as Profile);
+    return <Navigate to={dashboardUrl} replace />;
   }
 
   return <>{children}</>;

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -4,7 +4,8 @@ import { useAuth } from '@/contexts/AuthContext';
 import { Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card } from '@/components/ui/card';
-import { Role } from '@/contexts/auth/types';
+import { Role, Profile } from '@/contexts/auth/types';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 import { ThemeToggle } from '@/components/ThemeProvider';
 import Logo from '@/components/Logo';
 import AuthLoginForm from './components/AuthLoginForm';
@@ -37,8 +38,11 @@ const AuthPage = () => {
 
   // Redirect if already logged in
   if (user && profile && !isTransitioning) {
-    console.log("AuthPage: User is logged in, redirecting based on role:", profile.role);
-    const redirectPath = profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+    console.log(
+      "AuthPage: User is logged in, redirecting based on role:",
+      profile.role
+    );
+    const redirectPath = getDashboardUrl(profile);
     const from = location.state?.from?.pathname || redirectPath;
     return <Navigate to={from} replace />;
   }
@@ -47,7 +51,7 @@ const AuthPage = () => {
   if (isDemoMode() && !user) {
     const demoRole = localStorage.getItem('demoRole') as Role | null;
     if (demoRole) {
-      const redirectPath = demoRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: demoRole } as Profile);
       console.log("AuthPage: Demo mode active, redirecting to", redirectPath);
       return <Navigate to={redirectPath} replace />;
     }
@@ -63,7 +67,7 @@ const AuthPage = () => {
     setIsTransitioning(true);
     // Simulate loading and transition to dashboard
     setTimeout(() => {
-      const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: selectedRole } as Profile);
       console.log("AuthPage: Transitioning to", redirectPath);
       navigate(redirectPath, { replace: true });
       setIsTransitioning(false);

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -4,6 +4,8 @@ import { Role } from '@/contexts/auth/types';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
+import { Profile } from '@/contexts/auth/types';
 
 interface AuthDemoOptionsProps {
   selectedRole: Role;
@@ -35,10 +37,10 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
     initializeDemoMode(selectedRole);
     setIsTransitioning(true);
     
-    // Direct navigation based on role - using correct existing routes
-    const redirectPath = selectedRole === 'manager' ? '/manager-dashboard' : '/sales-rep-dashboard';
+    // Direct navigation based on role
+    const redirectPath = getDashboardUrl({ role: selectedRole } as Profile);
     console.log("Redirecting to:", redirectPath);
-    
+
     setTimeout(() => {
       navigate(redirectPath);
     }, 1500);

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -8,6 +8,8 @@ import { LogIn } from 'lucide-react';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
+import { Profile } from '@/contexts/auth/types';
 
 interface AuthLoginFormProps {
   setIsTransitioning: (value: boolean) => void;
@@ -104,15 +106,19 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
       // Direct navigation based on settings status
       setTimeout(() => {
         if (companyStatus) {
-          if (companyStatus.isManager && (!companyStatus.hasSettings || !companyStatus.onboardingCompleted)) {
+          if (
+            companyStatus.isManager &&
+            (!companyStatus.hasSettings || !companyStatus.onboardingCompleted)
+          ) {
             // Manager with no company settings or incomplete onboarding -> onboarding
             navigate('/onboarding');
           } else {
             // Regular navigation based on role
-            navigate('/sales-rep-dashboard');
+            const role = companyStatus.isManager ? 'manager' : 'sales_rep';
+            navigate(getDashboardUrl({ role } as Profile));
           }
         } else {
-          navigate('/sales-rep-dashboard');
+          navigate(getDashboardUrl(null));
         }
       }, 1500);
       


### PR DESCRIPTION
## Summary
- update dashboard url helper
- update login & demo screens to use helper
- use helper when redirecting based on role
- update dev role toggle and DashboardRouter paths
- switch old dashboard links to new `/sales/dashboard`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68411c9c85a883289c65f71b87167ff5