### PR TITLE
Fix demo role string in DashboardRouter

### DIFF
--- a/src/components/DashboardRouter.tsx
+++ b/src/components/DashboardRouter.tsx
@@ -18,7 +18,7 @@ const DashboardRouter = () => {
   // Handle demo mode
   if (userStatus === 'demo' && demoRole) {
     switch (demoRole) {
-      case 'sales-rep':
+      case 'sales_rep':
         return <Navigate to="/" replace />;
       case 'manager':
         return <Navigate to="/manager/dashboard" replace />;


### PR DESCRIPTION
## Summary
- handle demo login as `sales_rep` in DashboardRouter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684120f3c3a8832899014f25d633362f