### PR TITLE
Update DashboardRouter demo-mode handling

### DIFF
--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -73,7 +73,6 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
               onClick={() => {
                 localStorage.removeItem('demoMode');
                 localStorage.removeItem('demoRole');
-                localStorage.removeItem('userStatus');
                 localStorage.removeItem('planType');
                 window.location.href = '/auth';
               }}

--- a/src/components/DashboardRouter.tsx
+++ b/src/components/DashboardRouter.tsx
@@ -4,7 +4,7 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 
 const DashboardRouter = () => {
-  const { user, profile } = useAuth();
+  const { user, profile, isDemoMode, getLastSelectedRole } = useAuth();
   
   // If not authenticated, redirect to auth
   if (!user) {
@@ -12,11 +12,10 @@ const DashboardRouter = () => {
   }
   
   // Route based on user role or demo mode
-  const userStatus = localStorage.getItem('userStatus');
-  const demoRole = localStorage.getItem('demoRole');
-  
+
   // Handle demo mode
-  if (userStatus === 'demo' && demoRole) {
+  if (isDemoMode()) {
+    const demoRole = getLastSelectedRole();
     switch (demoRole) {
       case 'sales_rep':
         return <Navigate to="/" replace />;

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -89,8 +89,7 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
       // Simulate full user authentication with all features unlocked
       initializeDemoMode('sales_rep');
       
-      // Set full user status in localStorage
-      localStorage.setItem('userStatus', 'full');
+      // Store the plan type and email for demo purposes
       localStorage.setItem('planType', 'pro');
       localStorage.setItem('userEmail', formData.email);
       


### PR DESCRIPTION
## Summary
- use `isDemoMode` and `getLastSelectedRole` in `DashboardRouter`
- drop outdated `userStatus` handling
- adjust login form and header to remove `userStatus`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841237b8af88328ac0ae65a83d50852