### PR TITLE
Add linting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,15 @@ const { data, error } = await supabase.functions.invoke('elevenlabs-speech', {
 ```
 
 The client now uses this function for speech synthesis instead of reading `VITE_ELEVENLABS_API_KEY` directly.
+
+## Linting
+
+Before running the linter make sure the dependencies are installed. Run either
+`npm install` or `bun install` in the project root. After the installation is
+complete you can execute the `lint` script with:
+
+```sh
+npm run lint
+```
+
+This script is defined in `package.json` and runs ESLint across the project.


### PR DESCRIPTION
## Summary
- add instructions for installing dependencies before running the `lint` script

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684123c619bc83289ec50e8cd20f66c1