### PR TITLE
Replace console calls with logger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
@@ -32,7 +33,7 @@ const queryClient = new QueryClient({
 });
 
 function App() {
-  console.log('App component rendering');
+  logger.info('App component rendering');
   
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/AI/ContextAwareAIAssistant.tsx
+++ b/src/components/AI/ContextAwareAIAssistant.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
@@ -140,13 +141,13 @@ const ContextAwareAIAssistant: React.FC<ContextAwareAIAssistantProps> = ({
             window.speechSynthesis.speak(utterance);
           }
         } catch (voiceError) {
-          console.warn('Voice response failed:', voiceError);
+          logger.warn('Voice response failed:', voiceError);
         }
       }
 
       toast.success(`AI response generated ${aiResponse.source ? `(${aiResponse.source})` : ''}`);
     } catch (error) {
-      console.error('Error processing AI command:', error);
+      logger.error('Error processing AI command:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to process AI command';
       
       toast.error(errorMessage);
@@ -196,7 +197,7 @@ const ContextAwareAIAssistant: React.FC<ContextAwareAIAssistantProps> = ({
     };
 
     recognitionRef.current.onerror = (event: any) => {
-      console.error('Speech recognition error:', event.error);
+      logger.error('Speech recognition error:', event.error);
       toast.error('Speech recognition failed');
     };
 

--- a/src/components/AI/VoiceAIAssistant.tsx
+++ b/src/components/AI/VoiceAIAssistant.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
@@ -48,7 +49,7 @@ const VoiceAIAssistant: React.FC<VoiceAIAssistantProps> = ({
         toast.error('Failed to start voice recognition');
       }
     } catch (error) {
-      console.error('Error starting voice recognition:', error);
+      logger.error('Error starting voice recognition:', error);
       setIsListening(false);
       toast.error('Voice recognition error');
     }
@@ -80,7 +81,7 @@ const VoiceAIAssistant: React.FC<VoiceAIAssistantProps> = ({
         toast.success('Command processed successfully');
       }
     } catch (error) {
-      console.error('Error processing voice command:', error);
+      logger.error('Error processing voice command:', error);
       setIsListening(false);
       setIsSpeaking(false);
       toast.error('Failed to process voice command');

--- a/src/components/AI/VoiceAssistant.tsx
+++ b/src/components/AI/VoiceAssistant.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from "react";
 
@@ -20,11 +21,11 @@ const VoiceAssistant = () => {
       recognition.onresult = (event: any) => {
         const speech = event.results[0][0].transcript;
         setTranscript(speech);
-        console.log("User said:", speech);
+        logger.info("User said:", speech);
       };
 
       recognition.onerror = (event: any) => {
-        console.error("Speech recognition error:", event.error);
+        logger.error("Speech recognition error:", event.error);
         setListening(false);
       };
 
@@ -40,7 +41,7 @@ const VoiceAssistant = () => {
         setListening(true);
       }
     } catch (error) {
-      console.error("Error with speech recognition:", error);
+      logger.error("Error with speech recognition:", error);
       setListening(false);
     }
   };

--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card";
@@ -135,7 +136,7 @@ const AIAssistant = () => {
         setMessages(prevMessages => [...prevMessages, aiMessage]);
         
       } catch (err: any) {
-        console.error("Error processing AI response:", err);
+        logger.error("Error processing AI response:", err);
         toast.error("Failed to get AI response");
         
         // Add error message
@@ -204,7 +205,7 @@ const AIAssistant = () => {
       setMessages(prevMessages => [...prevMessages, aiMessage]);
       
     } catch (err) {
-      console.error("Error processing suggested action:", err);
+      logger.error("Error processing suggested action:", err);
       
       // Add error message
       const aiMessage: AIMessage = {

--- a/src/components/AIAssistant/AIAssistantHelper.tsx
+++ b/src/components/AIAssistant/AIAssistantHelper.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -115,7 +116,7 @@ const AIAssistantHelper: React.FC<AIAssistantHelperProps> = ({
           .single();
           
         if (error) {
-          console.error('Error checking tour status:', error);
+          logger.error('Error checking tour status:', error);
           return;
         }
         
@@ -136,7 +137,7 @@ const AIAssistantHelper: React.FC<AIAssistantHelperProps> = ({
           setMessage(introMessage || generateMessage('greeting'));
         }
       } catch (err) {
-        console.error('Error in checkTourStatus:', err);
+        logger.error('Error in checkTourStatus:', err);
       }
     };
     
@@ -157,7 +158,7 @@ const AIAssistantHelper: React.FC<AIAssistantHelperProps> = ({
         event_data: {}
       });
     } catch (err) {
-      console.error('Error tracking tour start:', err);
+      logger.error('Error tracking tour start:', err);
     }
   };
 
@@ -184,7 +185,7 @@ const AIAssistantHelper: React.FC<AIAssistantHelperProps> = ({
       // Set a new message
       setMessage(`Great! You're all set to use ${agentName}. Let me know if you need anything else.`);
     } catch (err) {
-      console.error('Error completing tour:', err);
+      logger.error('Error completing tour:', err);
     }
   };
 

--- a/src/components/AIBrain/AIBrainReindex.tsx
+++ b/src/components/AIBrain/AIBrainReindex.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -41,7 +42,7 @@ const AIBrainReindex: React.FC = () => {
         }
       }
     } catch (err: any) {
-      console.error("Error fetching reindex job info:", err);
+      logger.error("Error fetching reindex job info:", err);
     }
   };
 
@@ -60,7 +61,7 @@ const AIBrainReindex: React.FC = () => {
       const { data, error } = await supabase.functions.invoke('ai-brain-reindex');
 
       if (error) {
-        console.error("Error reindexing AI Brain data:", error);
+        logger.error("Error reindexing AI Brain data:", error);
         setError(error.message || "Error reindexing data");
         toast.error("Failed to reindex AI Brain data");
         return;
@@ -79,7 +80,7 @@ const AIBrainReindex: React.FC = () => {
       }
       
     } catch (err: any) {
-      console.error("Exception when reindexing AI Brain data:", err);
+      logger.error("Exception when reindexing AI Brain data:", err);
       setError(err.message || "Unknown error occurred");
       toast.error("Failed to reindex data");
     } finally {

--- a/src/components/AIBrain/CaseStudies/useCaseStudies.ts
+++ b/src/components/AIBrain/CaseStudies/useCaseStudies.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from "@/integrations/supabase/client";
@@ -48,7 +49,7 @@ export function useCaseStudies(
       if (error) throw error;
       setCaseStudies(data as CaseStudy[]);
     } catch (err) {
-      console.error("Error fetching case studies:", err);
+      logger.error("Error fetching case studies:", err);
       toast.error("Failed to fetch case studies");
     } finally {
       setIsLoading(false);
@@ -74,7 +75,7 @@ export function useCaseStudies(
       
       setIndustries(uniqueIndustries);
     } catch (err) {
-      console.error("Error fetching industries:", err);
+      logger.error("Error fetching industries:", err);
     }
   };
 

--- a/src/components/AIBrain/KnowledgeChat.tsx
+++ b/src/components/AIBrain/KnowledgeChat.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "@/components/ui/card";
@@ -83,7 +84,7 @@ const KnowledgeChat = () => {
         }]);
       }
     } catch (error) {
-      console.error("Error querying knowledge:", error);
+      logger.error("Error querying knowledge:", error);
       toast.error("Failed to query knowledge");
     } finally {
       setIsLoading(false);

--- a/src/components/AIBrain/KnowledgeLibrary.tsx
+++ b/src/components/AIBrain/KnowledgeLibrary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -46,7 +47,7 @@ const KnowledgeLibrary: React.FC<KnowledgeLibraryProps> = ({ isManager }) => {
           .single();
           
         if (error) {
-          console.error("Error fetching user's company_id:", error);
+          logger.error("Error fetching user's company_id:", error);
           return;
         }
         
@@ -54,7 +55,7 @@ const KnowledgeLibrary: React.FC<KnowledgeLibraryProps> = ({ isManager }) => {
           setCompanyId(data.company_id);
         }
       } catch (err) {
-        console.error("Error in fetching company ID:", err);
+        logger.error("Error in fetching company ID:", err);
       }
     };
     
@@ -96,7 +97,7 @@ const KnowledgeLibrary: React.FC<KnowledgeLibraryProps> = ({ isManager }) => {
       if (error) throw error;
       setEntries(data as KnowledgeEntry[]);
     } catch (err) {
-      console.error("Error fetching knowledge entries:", err);
+      logger.error("Error fetching knowledge entries:", err);
       toast.error("Failed to fetch knowledge entries");
     } finally {
       setIsLoading(false);
@@ -124,7 +125,7 @@ const KnowledgeLibrary: React.FC<KnowledgeLibraryProps> = ({ isManager }) => {
         throw new Error(data.error || "Reindex failed");
       }
     } catch (err: any) {
-      console.error("Error reindexing:", err);
+      logger.error("Error reindexing:", err);
       toast.error(err.message || "Failed to reindex knowledge base");
     } finally {
       setIsReindexing(false);
@@ -153,7 +154,7 @@ const KnowledgeLibrary: React.FC<KnowledgeLibraryProps> = ({ isManager }) => {
         // Refresh entries to update the list
         fetchEntries();
       } catch (err) {
-        console.error("Error deleting entry:", err);
+        logger.error("Error deleting entry:", err);
         toast.error("Failed to delete entry");
       }
     }
@@ -178,7 +179,7 @@ const KnowledgeLibrary: React.FC<KnowledgeLibraryProps> = ({ isManager }) => {
       // Refresh entries to update the list
       fetchEntries();
     } catch (err) {
-      console.error("Error marking as case study:", err);
+      logger.error("Error marking as case study:", err);
       toast.error("Failed to mark as case study");
     }
   };

--- a/src/components/AIBrain/KnowledgeUpload.tsx
+++ b/src/components/AIBrain/KnowledgeUpload.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -79,7 +80,7 @@ const KnowledgeUpload = () => {
               toast.success(`Successfully processed ${result.chunks_success} of ${result.chunks_total} chunks`);
             }
           } catch (error) {
-            console.error("Error processing file:", error);
+            logger.error("Error processing file:", error);
             toast.error("Failed to process file");
           } finally {
             setFile(null);
@@ -117,7 +118,7 @@ const KnowledgeUpload = () => {
             throw new Error('Failed to process URL');
           }
         } catch (error) {
-          console.error("Error processing URL:", error);
+          logger.error("Error processing URL:", error);
           toast.error("Failed to process URL content");
         } finally {
           setWebUrl('');
@@ -127,7 +128,7 @@ const KnowledgeUpload = () => {
         }
       }
     } catch (error) {
-      console.error("Error in upload process:", error);
+      logger.error("Error in upload process:", error);
       toast.error("An error occurred during the upload process");
       setIsProcessing(false);
       setProgress(0);

--- a/src/components/AutoDialer/AutoDialerInterface.tsx
+++ b/src/components/AutoDialer/AutoDialerInterface.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
@@ -146,7 +147,7 @@ const AutoDialerInterface: React.FC<AutoDialerInterfaceProps> = ({
   };
 
   const handleFeedbackSubmit = (feedback: any) => {
-    console.log('Call feedback:', feedback);
+    logger.info('Call feedback:', feedback);
     toast.success('Feedback submitted successfully');
   };
 

--- a/src/components/AutoDialer/DialerOverlay.tsx
+++ b/src/components/AutoDialer/DialerOverlay.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
@@ -105,7 +106,7 @@ const DialerOverlay: React.FC<DialerOverlayProps> = ({
         toast.info('📋 Opening objection handling scripts...');
         break;
       default:
-        console.log('Dialer AI Action:', action, data);
+        logger.info('Dialer AI Action:', action, data);
     }
   };
 

--- a/src/components/Automation/WorkflowBuilder.tsx
+++ b/src/components/Automation/WorkflowBuilder.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -44,7 +45,7 @@ const WorkflowBuilder = () => {
       // For demo purposes, use mock data
       setWorkflows(mockWorkflows as Workflow[]);
     } catch (error) {
-      console.error('Failed to load workflows:', error);
+      logger.error('Failed to load workflows:', error);
       toast.error('Failed to load workflows');
     } finally {
       setIsLoading(false);
@@ -79,7 +80,7 @@ const WorkflowBuilder = () => {
       });
       toast.success('Workflow created successfully');
     } catch (error) {
-      console.error('Failed to create workflow:', error);
+      logger.error('Failed to create workflow:', error);
       toast.error('Failed to create workflow');
     }
   };
@@ -91,7 +92,7 @@ const WorkflowBuilder = () => {
       );
       toast.success(`Workflow ${isActive ? 'activated' : 'deactivated'}`);
     } catch (error) {
-      console.error('Failed to toggle workflow:', error);
+      logger.error('Failed to toggle workflow:', error);
       toast.error('Failed to toggle workflow');
     }
   };
@@ -101,7 +102,7 @@ const WorkflowBuilder = () => {
       setWorkflows(prev => prev.filter(w => w.id !== workflowId));
       toast.success('Workflow deleted successfully');
     } catch (error) {
-      console.error('Failed to delete workflow:', error);
+      logger.error('Failed to delete workflow:', error);
       toast.error('Failed to delete workflow');
     }
   };

--- a/src/components/CRM/CRMIntegrationManager.tsx
+++ b/src/components/CRM/CRMIntegrationManager.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -70,7 +71,7 @@ const CRMIntegrationManager: React.FC = () => {
               syncErrors: status.syncErrors
             });
           } catch (error) {
-            console.error(`Failed to get ${config.name} status:`, error);
+            logger.error(`Failed to get ${config.name} status:`, error);
             statuses.push({
               name: config.name,
               icon: config.icon,
@@ -94,7 +95,7 @@ const CRMIntegrationManager: React.FC = () => {
 
       setCrmStatuses(statuses);
     } catch (error) {
-      console.error('Failed to fetch CRM statuses:', error);
+      logger.error('Failed to fetch CRM statuses:', error);
       toast.error('Failed to refresh CRM statuses');
     } finally {
       setIsRefreshing(false);
@@ -127,7 +128,7 @@ const CRMIntegrationManager: React.FC = () => {
         toast.error(result?.error || `Failed to connect ${crmName}`);
       }
     } catch (error) {
-      console.error(`Failed to connect ${crmName}:`, error);
+      logger.error(`Failed to connect ${crmName}:`, error);
       toast.error(`Failed to connect ${crmName}`);
     }
   };
@@ -145,7 +146,7 @@ const CRMIntegrationManager: React.FC = () => {
         toast.error(result.error || `Failed to disconnect ${crmName}`);
       }
     } catch (error) {
-      console.error(`Failed to disconnect ${crmName}:`, error);
+      logger.error(`Failed to disconnect ${crmName}:`, error);
       toast.error(`Failed to disconnect ${crmName}`);
     }
   };
@@ -178,7 +179,7 @@ const CRMIntegrationManager: React.FC = () => {
         toast.error(`${crmName} sync failed`);
       }
     } catch (error) {
-      console.error(`Failed to sync ${crmName}:`, error);
+      logger.error(`Failed to sync ${crmName}:`, error);
       toast.error(`Failed to sync ${crmName}`);
     } finally {
       await fetchCRMStatuses();

--- a/src/components/Dashboard/AIDailySummary.tsx
+++ b/src/components/Dashboard/AIDailySummary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -20,7 +21,7 @@ const AIDailySummary: React.FC<AIDailySummaryProps> = ({
     if (isPlaying) return;
     try {
       setIsPlaying(true);
-      console.log('Starting audio playback for summary');
+      logger.info('Starting audio playback for summary');
       toast.info('Generating voice summary... (Test Mode)');
 
       // Validate summary before playing
@@ -36,7 +37,7 @@ const AIDailySummary: React.FC<AIDailySummaryProps> = ({
       await voiceService.generateVoiceResponse(voiceText);
       toast.success('Summary played successfully (Test Mode)');
     } catch (error) {
-      console.error('Error playing audio summary:', error);
+      logger.error('Error playing audio summary:', error);
       const errorMessage = error instanceof Error ? error.message : 'Failed to play audio summary';
       const safeErrorMessage = validateStringParam(errorMessage, 'Audio playback failed');
       toast.error(safeErrorMessage);

--- a/src/components/Developer/DeveloperLogs.tsx
+++ b/src/components/Developer/DeveloperLogs.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -51,7 +52,7 @@ const DeveloperLogs: React.FC = () => {
       if (error) throw error;
       setLogs(data || []);
     } catch (error) {
-      console.error('Error fetching logs:', error);
+      logger.error('Error fetching logs:', error);
     } finally {
       setLoading(false);
     }

--- a/src/components/DeveloperMode/RoleToggle.tsx
+++ b/src/components/DeveloperMode/RoleToggle.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
@@ -28,7 +29,7 @@ const RoleToggle: React.FC = () => {
       const redirectPath = newRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
       window.location.href = redirectPath;
     } catch (error) {
-      console.error('Error toggling role:', error);
+      logger.error('Error toggling role:', error);
       toast.error('Failed to switch role');
     }
   };

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -24,7 +25,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Error caught by boundary:', error, errorInfo);
+    logger.error('Error caught by boundary:', error, errorInfo);
   }
 
   handleRetry = () => {

--- a/src/components/ErrorBoundary/SafeErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/SafeErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -27,7 +28,7 @@ export class SafeErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('Error caught by SafeErrorBoundary:', error, errorInfo);
+    logger.error('Error caught by SafeErrorBoundary:', error, errorInfo);
     this.setState({ error, errorInfo });
   }
 

--- a/src/components/Layout/ErrorBoundary.tsx
+++ b/src/components/Layout/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -26,7 +27,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    logger.error('ErrorBoundary caught an error:', error, errorInfo);
     this.setState({
       error,
       errorInfo

--- a/src/components/LeadImport/LeadImportDialog.tsx
+++ b/src/components/LeadImport/LeadImportDialog.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useCallback, useRef } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -79,7 +80,7 @@ const LeadImportDialog: React.FC<LeadImportDialogProps> = ({
       setCurrentStep('mapping');
       toast.success('File uploaded successfully');
     } catch (error) {
-      console.error('Error processing file:', error);
+      logger.error('Error processing file:', error);
       toast.error('Failed to process file');
     }
   }, [parseCSVFile, createImportSession]);

--- a/src/components/LeadIntelligence/LeadSummary.tsx
+++ b/src/components/LeadIntelligence/LeadSummary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -63,7 +64,7 @@ const LeadSummary: React.FC<LeadSummaryProps> = ({
       }, 2000);
     } catch (error) {
       setIsGenerating(false);
-      console.error('Error generating AI summary:', error);
+      logger.error('Error generating AI summary:', error);
     }
   };
 

--- a/src/components/LeadIntelligence/VoiceControls.tsx
+++ b/src/components/LeadIntelligence/VoiceControls.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
@@ -32,7 +33,7 @@ const VoiceControls: React.FC<VoiceControlsProps> = ({
         const permitted = await voiceService.requestMicrophonePermission();
         setHasPermission(permitted);
       } catch (error) {
-        console.error('Permission check failed:', error);
+        logger.error('Permission check failed:', error);
         setHasPermission(false);
       }
     };
@@ -74,10 +75,10 @@ const VoiceControls: React.FC<VoiceControlsProps> = ({
       }
 
       toast.info(`Listening for voice commands about ${leadName}...`);
-      console.log('Voice recording started successfully');
+      logger.info('Voice recording started successfully');
 
     } catch (error) {
-      console.error('Failed to start listening:', error);
+      logger.error('Failed to start listening:', error);
       setIsListening(false);
       toast.error('Failed to start voice recording');
     }
@@ -89,7 +90,7 @@ const VoiceControls: React.FC<VoiceControlsProps> = ({
       setIsProcessing(true);
       trackClick('voice_command', 'stop');
 
-      console.log('Stopping voice recording...');
+      logger.info('Stopping voice recording...');
       const audioBlob = await voiceService.stopRecording();
       
       if (!audioBlob || audioBlob.size === 0) {
@@ -98,14 +99,14 @@ const VoiceControls: React.FC<VoiceControlsProps> = ({
         return;
       }
 
-      console.log('Processing voice command...');
+      logger.info('Processing voice command...');
       toast.info('Processing your voice command...');
 
       // Process the audio
       const transcription = await voiceService.processAudioCommand(audioBlob, 'current-user');
       
       if (transcription && transcription.trim()) {
-        console.log('Voice command transcribed:', transcription);
+        logger.info('Voice command transcribed:', transcription);
         toast.success('Voice command processed successfully!');
         
         // Call the callback with the transcribed text
@@ -121,7 +122,7 @@ const VoiceControls: React.FC<VoiceControlsProps> = ({
       }
 
     } catch (error) {
-      console.error('Voice command processing failed:', error);
+      logger.error('Voice command processing failed:', error);
       toast.error(error.message || 'Failed to process voice command');
     } finally {
       setIsProcessing(false);

--- a/src/components/LeadManagement/LeadCard.tsx
+++ b/src/components/LeadManagement/LeadCard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
@@ -67,7 +68,7 @@ const LeadCard: React.FC<LeadCardProps> = ({
   };
 
   const handleCardClick = () => {
-    console.log('LeadCard clicked - Lead ID:', lead.id, 'Lead Name:', lead.name);
+    logger.info('LeadCard clicked - Lead ID:', lead.id, 'Lead Name:', lead.name);
     onCardClick(lead);
   };
 

--- a/src/components/LeadManagement/LeadCardGrid.tsx
+++ b/src/components/LeadManagement/LeadCardGrid.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -118,7 +119,7 @@ const LeadCardGrid: React.FC<LeadCardGridProps> = ({
   };
 
   const handleLeadClick = (lead: Lead) => {
-    console.log('Navigating to lead workspace:', lead.id);
+    logger.info('Navigating to lead workspace:', lead.id);
     // Navigate to the standalone lead workspace route
     navigate(`/lead-workspace/${lead.id}`);
     trackEvent({

--- a/src/components/LeadManagement/LeadManagementTabs.tsx
+++ b/src/components/LeadManagement/LeadManagementTabs.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -24,7 +25,7 @@ const LeadManagementTabs: React.FC<LeadManagementTabsProps> = ({
   const qualifiedLeads = leads.filter(lead => lead.status === 'qualified');
 
   const handleQuickAction = (action: string, lead: Lead) => {
-    console.log('Quick action:', action, 'for lead:', lead);
+    logger.info('Quick action:', action, 'for lead:', lead);
     // Handle quick actions here
   };
 

--- a/src/components/LeadWorkspace/tabs/LeadNotesTab.tsx
+++ b/src/components/LeadWorkspace/tabs/LeadNotesTab.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -54,7 +55,7 @@ const LeadNotesTab: React.FC<LeadNotesTabProps> = ({ lead }) => {
         }
         break;
       default:
-        console.log('Notes AI Action:', action, data);
+        logger.info('Notes AI Action:', action, data);
     }
   };
 

--- a/src/components/LogoutHandler.tsx
+++ b/src/components/LogoutHandler.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -8,7 +9,7 @@ const LogoutHandler = () => {
   useEffect(() => {
     const handleLogout = async () => {
       try {
-        console.log('LogoutHandler: Starting logout process');
+        logger.info('LogoutHandler: Starting logout process');
         
         // Clear all local storage and session storage first
         localStorage.clear();
@@ -26,13 +27,13 @@ const LogoutHandler = () => {
         // Sign out from auth
         await signOut();
         
-        console.log('LogoutHandler: Forcing redirect to auth');
+        logger.info('LogoutHandler: Forcing redirect to auth');
         
         // Force a complete page reload to the auth page to clear all state
         window.location.replace('/auth');
         
       } catch (error) {
-        console.error('LogoutHandler error:', error);
+        logger.error('LogoutHandler error:', error);
         // Force redirect even on error
         localStorage.clear();
         sessionStorage.clear();

--- a/src/components/ManagerAI/ManagerAIPanel.tsx
+++ b/src/components/ManagerAI/ManagerAIPanel.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -70,7 +71,7 @@ const ManagerAIPanel: React.FC<ManagerAIPanelProps> = ({
         toast.success('Jarvis response generated');
       }
     } catch (error) {
-      console.error('Error asking Jarvis:', error);
+      logger.error('Error asking Jarvis:', error);
       toast.error('Failed to get response from Jarvis');
     } finally {
       setIsProcessing(false);
@@ -101,7 +102,7 @@ const ManagerAIPanel: React.FC<ManagerAIPanelProps> = ({
         toast.success('Executive report generated');
       }
     } catch (error) {
-      console.error('Error generating report:', error);
+      logger.error('Error generating report:', error);
       toast.error('Failed to generate report');
     } finally {
       setIsProcessing(false);

--- a/src/components/MasterBrain/DeveloperDashboard.tsx
+++ b/src/components/MasterBrain/DeveloperDashboard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -54,7 +55,7 @@ const DeveloperDashboard: React.FC = () => {
       const companyImprovements = await aiLearningLayer.getCompanyImprovements(profile.company_id);
       setImprovements(companyImprovements);
     } catch (error) {
-      console.error('Failed to load system improvements:', error);
+      logger.error('Failed to load system improvements:', error);
     } finally {
       setIsLoading(false);
     }
@@ -65,7 +66,7 @@ const DeveloperDashboard: React.FC = () => {
       await aiLearningLayer.markImprovementAsImplemented(improvementId);
       setImprovements(prev => prev.filter(imp => imp.id !== improvementId));
     } catch (error) {
-      console.error('Failed to mark improvement as implemented:', error);
+      logger.error('Failed to mark improvement as implemented:', error);
     }
   };
 

--- a/src/components/Navigation/DeveloperNavigation.tsx
+++ b/src/components/Navigation/DeveloperNavigation.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -46,14 +47,14 @@ const DeveloperNavigation: React.FC = () => {
     setTestMode(nextMode);
     
     // In Developer OS, we can simulate different OS views for testing
-    console.log(`Developer Testing: Simulating ${nextMode} experience`);
+    logger.info(`Developer Testing: Simulating ${nextMode} experience`);
   };
 
   const handleLogout = async () => {
     try {
       await signOut();
     } catch (error) {
-      console.error('Logout failed:', error);
+      logger.error('Logout failed:', error);
     }
   };
 

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
@@ -11,7 +12,7 @@ const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
   const { user, profile, loading, isDemoMode } = useAuth();
   const location = useLocation();
 
-  console.log('RequireAuth check:', { 
+  logger.info('RequireAuth check:', { 
     loading, 
     user: !!user, 
     profile: !!profile, 
@@ -30,13 +31,13 @@ const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
 
   // Allow demo mode access
   if (isDemoMode()) {
-    console.log('RequireAuth: Demo mode active, allowing access');
+    logger.info('RequireAuth: Demo mode active, allowing access');
     return <>{children}</>;
   }
 
   // If no user and not in demo mode, redirect to auth
   if (!user) {
-    console.log('RequireAuth: No user, redirecting to auth');
+    logger.info('RequireAuth: No user, redirecting to auth');
     // Force a complete redirect to clear any cached state
     window.location.replace('/auth');
     return null;
@@ -44,11 +45,11 @@ const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
 
   // If user is authenticated but no profile, redirect to auth for completion
   if (!profile) {
-    console.log('RequireAuth: User but no profile, redirecting to auth');
+    logger.info('RequireAuth: User but no profile, redirecting to auth');
     return <Navigate to="/auth" replace />;
   }
 
-  console.log('RequireAuth: Access granted');
+  logger.info('RequireAuth: Access granted');
   return <>{children}</>;
 };
 

--- a/src/components/Settings/IntegrationSettings.tsx
+++ b/src/components/Settings/IntegrationSettings.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';

--- a/src/components/SystemHealth/HealthMonitor.tsx
+++ b/src/components/SystemHealth/HealthMonitor.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -33,7 +34,7 @@ const HealthMonitor: React.FC = () => {
     // Log health status
     const hasErrors = checks.some(check => check.status === 'error');
     const hasWarnings = checks.some(check => check.status === 'warning');
-    console.log('System Health Check:', {
+    logger.info('System Health Check:', {
       overall: hasErrors ? 'error' : hasWarnings ? 'warning' : 'healthy',
       checks: checks.map(c => ({
         name: c.name,

--- a/src/components/UnifiedAI/EnhancedUnifiedAIBubble.tsx
+++ b/src/components/UnifiedAI/EnhancedUnifiedAIBubble.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Button } from '@/components/ui/button';
@@ -183,7 +184,7 @@ const EnhancedUnifiedAIBubble: React.FC<EnhancedUnifiedAIBubbleProps> = ({
         break;
 
       default:
-        console.log('AI Action:', action, data);
+        logger.info('AI Action:', action, data);
     }
 
     // Log the interaction

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -25,10 +26,10 @@ const UserProfile: React.FC<UserProfileProps> = ({ name, role }) => {
     try {
       // For now, we'll just redirect to auth page
       // The AuthContext might not have a logout method yet
-      console.log('Logout requested');
+      logger.info('Logout requested');
       window.location.href = '/auth';
     } catch (error) {
-      console.error('Logout failed:', error);
+      logger.error('Logout failed:', error);
     }
   };
 

--- a/src/components/VoiceAI/ContextAwareVoiceAssistant.tsx
+++ b/src/components/VoiceAI/ContextAwareVoiceAssistant.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
@@ -70,7 +71,7 @@ const ContextAwareVoiceAssistant: React.FC<ContextAwareVoiceAssistantProps> = ({
   };
 
   const handleAction = (action: string, data?: any) => {
-    console.log('AI Action:', action, data);
+    logger.info('AI Action:', action, data);
     // Handle various AI actions based on the action type
     switch (action) {
       case 'initiate_call':
@@ -83,7 +84,7 @@ const ContextAwareVoiceAssistant: React.FC<ContextAwareVoiceAssistantProps> = ({
         // Show objection handling scripts
         break;
       default:
-        console.log('Unhandled action:', action);
+        logger.info('Unhandled action:', action);
     }
   };
 

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -28,7 +29,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    logger.error('ErrorBoundary caught an error:', error, errorInfo);
     
     this.setState({
       error,
@@ -58,12 +59,12 @@ export class ErrorBoundary extends Component<Props, State> {
         url: window.location.href
       };
 
-      console.log('Error logged:', errorData);
+      logger.info('Error logged:', errorData);
       
       // In production, send to logging service
       // await logToService(errorData);
     } catch (logError) {
-      console.error('Failed to log error:', logError);
+      logger.error('Failed to log error:', logError);
     }
   };
 

--- a/src/contexts/UnifiedAIContext.tsx
+++ b/src/contexts/UnifiedAIContext.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useAuth } from './AuthContext';
 import { masterAIBrain } from '@/services/masterAIBrain';
@@ -75,7 +76,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
       }
 
     } catch (error) {
-      console.error('Error initializing AI:', error);
+      logger.error('Error initializing AI:', error);
       addAIError('Failed to initialize AI system');
     }
   };
@@ -92,7 +93,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
       
       return response.response;
     } catch (error) {
-      console.error('Error generating AI response:', error);
+      logger.error('Error generating AI response:', error);
       addAIError('Failed to generate AI response');
       throw error;
     }
@@ -110,7 +111,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
       
       return response;
     } catch (error) {
-      console.error('Error generating strategy response:', error);
+      logger.error('Error generating strategy response:', error);
       addAIError('Failed to generate strategy response');
       throw error;
     }
@@ -128,7 +129,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
       
       return response;
     } catch (error) {
-      console.error('Error generating communication:', error);
+      logger.error('Error generating communication:', error);
       addAIError('Failed to generate communication');
       throw error;
     }
@@ -150,7 +151,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
         }
       });
     } catch (error) {
-      console.error('Error logging user action:', error);
+      logger.error('Error logging user action:', error);
       addAIError('Failed to log user action');
     }
   };
@@ -170,7 +171,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
         }
       });
     } catch (error) {
-      console.error('Error logging AI interaction:', error);
+      logger.error('Error logging AI interaction:', error);
       addAIError('Failed to log AI interaction');
     }
   };
@@ -185,7 +186,7 @@ export const UnifiedAIProvider: React.FC<UnifiedAIProviderProps> = ({ children }
         await salesRepAI.getPersonalizedRecommendations();
       }
     } catch (error) {
-      console.error('Error getting AI recommendations:', error);
+      logger.error('Error getting AI recommendations:', error);
       addAIError('Failed to get AI recommendations');
     }
   };

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -31,12 +32,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       try {
         const { data: { session }, error } = await supabase.auth.getSession();
         if (error) {
-          console.error('Error getting session:', error);
+          logger.error('Error getting session:', error);
           setLoading(false);
           return;
         }
         
-        console.log('Initial session:', session?.user?.email || 'No session');
+        logger.info('Initial session:', session?.user?.email || 'No session');
         setSession(session);
         setUser(session?.user || null);
         
@@ -44,7 +45,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           await fetchProfile(session.user.id);
         }
       } catch (error) {
-        console.error('Error getting session:', error);
+        logger.error('Error getting session:', error);
       } finally {
         setLoading(false);
       }
@@ -55,11 +56,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (event, session) => {
-        console.log('Auth state changed:', event, session?.user?.email);
+        logger.info('Auth state changed:', event, session?.user?.email);
         
         if (event === 'SIGNED_OUT') {
           // Immediately clear all state on sign out
-          console.log('Clearing all auth state');
+          logger.info('Clearing all auth state');
           setSession(null);
           setUser(null);
           setProfile(null);
@@ -97,13 +98,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         .single();
 
       if (error) {
-        console.error('Error fetching profile:', error);
+        logger.error('Error fetching profile:', error);
         return;
       }
 
       setProfile(data);
     } catch (error) {
-      console.error('Error in fetchProfile:', error);
+      logger.error('Error in fetchProfile:', error);
     }
   };
 
@@ -120,7 +121,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       toast.success('Signed in successfully');
       return {};
     } catch (error) {
-      console.error('Sign in error:', error);
+      logger.error('Sign in error:', error);
       toast.error('An unexpected error occurred');
       return { error: error as AuthError };
     } finally {
@@ -147,7 +148,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       toast.success('Check your email for verification link');
       return {};
     } catch (error) {
-      console.error('Sign up error:', error);
+      logger.error('Sign up error:', error);
       toast.error('An unexpected error occurred');
       return { error: error as AuthError };
     } finally {
@@ -157,7 +158,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const signOut = async (): Promise<void> => {
     try {
-      console.log('SignOut: Starting logout process...');
+      logger.info('SignOut: Starting logout process...');
       
       // Clear state immediately to prevent any redirects during logout
       setUser(null);
@@ -173,13 +174,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       const { error } = await supabase.auth.signOut({ scope: 'global' });
       
       if (error) {
-        console.error('Supabase sign out error:', error);
+        logger.error('Supabase sign out error:', error);
       }
       
-      console.log('SignOut: Logout completed');
+      logger.info('SignOut: Logout completed');
       
     } catch (error) {
-      console.error('Sign out error:', error);
+      logger.error('Sign out error:', error);
       // Clear state even on error
       setUser(null);
       setProfile(null);

--- a/src/contexts/auth/demoMode.ts
+++ b/src/contexts/auth/demoMode.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { User } from '@supabase/supabase-js';
 import { Role, Profile } from './types';
@@ -6,7 +7,7 @@ export const initializeDemoUser = (role: Role): {
   demoUser: User;
   demoProfile: Profile;
 } => {
-  console.log("Initializing demo user with role:", role);
+  logger.info("Initializing demo user with role:", role);
   
   // Create a mock user for demo purposes with safe type casting
   const demoUser = {
@@ -26,8 +27,8 @@ export const initializeDemoUser = (role: Role): {
     role: role,
   };
 
-  console.log("Setting demo user:", demoUser);
-  console.log("Setting demo profile:", demoProfile);
+  logger.info("Setting demo user:", demoUser);
+  logger.info("Setting demo profile:", demoProfile);
   
   return { demoUser, demoProfile };
 };

--- a/src/hooks/useAIAgent.ts
+++ b/src/hooks/useAIAgent.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -24,7 +25,7 @@ export const useAIAgent = () => {
     setIsLoading(true);
     
     try {
-      console.log('Calling AI Agent with request:', request);
+      logger.info('Calling AI Agent with request:', request);
 
       // Mock AI response for now - in production this would call the AI service
       await new Promise(resolve => setTimeout(resolve, 1000));
@@ -37,11 +38,11 @@ export const useAIAgent = () => {
         }
       };
 
-      console.log('AI Agent response:', mockResponse);
+      logger.info('AI Agent response:', mockResponse);
       return mockResponse;
 
     } catch (error) {
-      console.error('AI Agent error:', error);
+      logger.error('AI Agent error:', error);
       toast.error('Failed to get AI response');
       return null;
     } finally {

--- a/src/hooks/useAIBrainInsights.ts
+++ b/src/hooks/useAIBrainInsights.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -40,7 +41,7 @@ export const useAIBrainInsights = () => {
       if (error) throw error;
       setInsights(data || []);
     } catch (error) {
-      console.error('Error fetching AI insights:', error);
+      logger.error('Error fetching AI insights:', error);
       toast.error('Failed to fetch AI insights');
     } finally {
       setIsLoading(false);
@@ -66,7 +67,7 @@ export const useAIBrainInsights = () => {
 
       toast.success('Insight accepted');
     } catch (error) {
-      console.error('Error accepting insight:', error);
+      logger.error('Error accepting insight:', error);
       toast.error('Failed to accept insight');
     }
   };
@@ -83,18 +84,18 @@ export const useAIBrainInsights = () => {
       setInsights(prev => prev.filter(insight => insight.id !== insightId));
       toast.success('Insight dismissed');
     } catch (error) {
-      console.error('Error dismissing insight:', error);
+      logger.error('Error dismissing insight:', error);
       toast.error('Failed to dismiss insight');
     }
   };
 
   const logGhostIntent = (intent: string, details?: string) => {
-    console.log('Ghost intent logged:', intent, details);
+    logger.info('Ghost intent logged:', intent, details);
     // Could store this for analytics later
   };
 
   const logInteraction = (data: any) => {
-    console.log('Interaction logged:', data);
+    logger.info('Interaction logged:', data);
     // Could store this for analytics later
   };
 
@@ -124,7 +125,7 @@ export const useAIBrainInsights = () => {
       setInsights(prev => [data, ...prev]);
       return data;
     } catch (error) {
-      console.error('Error generating insight:', error);
+      logger.error('Error generating insight:', error);
       return null;
     } finally {
       setIsAnalyzing(false);

--- a/src/hooks/useAIBrainStats.ts
+++ b/src/hooks/useAIBrainStats.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from "@/integrations/supabase/client";
@@ -41,7 +42,7 @@ export function useAIBrainStats() {
           .single();
           
         if (profileError) {
-          console.error("Error fetching user's company_id:", profileError);
+          logger.error("Error fetching user's company_id:", profileError);
         } else if (profileData) {
           companyId = profileData.company_id;
         }
@@ -128,7 +129,7 @@ export function useAIBrainStats() {
         trends
       });
     } catch (error) {
-      console.error("Error fetching brain stats:", error);
+      logger.error("Error fetching brain stats:", error);
       setStats(prev => ({ ...prev, isLoading: false }));
     }
   };

--- a/src/hooks/useAILearningInsights.ts
+++ b/src/hooks/useAILearningInsights.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { useEnhancedUsageTracking } from './useEnhancedUsageTracking';
@@ -60,7 +61,7 @@ export const useAILearningInsights = () => {
       });
       
     } catch (error) {
-      console.error('Error analyzing learning patterns:', error);
+      logger.error('Error analyzing learning patterns:', error);
     } finally {
       setIsAnalyzing(false);
     }

--- a/src/hooks/useAISecurityPosture.ts
+++ b/src/hooks/useAISecurityPosture.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -67,7 +68,7 @@ export const useAISecurityPosture = () => {
         }
 
       } catch (error) {
-        console.error('Security posture check failed:', error);
+        logger.error('Security posture check failed:', error);
         addSecurityEvent({
           type: 'api_misuse',
           severity: 'low',
@@ -93,7 +94,7 @@ export const useAISecurityPosture = () => {
     setSecurityEvents(prev => [newEvent, ...prev.slice(0, 49)]); // Keep last 50 events
 
     // Log to console for debugging
-    console.log('Security Event:', newEvent);
+    logger.info('Security Event:', newEvent);
   };
 
   const encryptSensitiveData = (data: any): string => {

--- a/src/hooks/useCallLogs.ts
+++ b/src/hooks/useCallLogs.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -36,7 +37,7 @@ export const useCallLogs = () => {
       if (error) throw error;
       setCallLogs(data || []);
     } catch (error) {
-      console.error('Error fetching call logs:', error);
+      logger.error('Error fetching call logs:', error);
     } finally {
       setIsLoading(false);
     }
@@ -61,7 +62,7 @@ export const useCallLogs = () => {
       setCallLogs(prev => [data, ...prev]);
       return data;
     } catch (error) {
-      console.error('Error creating call log:', error);
+      logger.error('Error creating call log:', error);
       toast.error('Failed to log call');
       return null;
     }
@@ -81,7 +82,7 @@ export const useCallLogs = () => {
       setCallLogs(prev => prev.map(log => log.id === id ? data : log));
       return data;
     } catch (error) {
-      console.error('Error updating call log:', error);
+      logger.error('Error updating call log:', error);
       return null;
     }
   };

--- a/src/hooks/useCompanyBrain.ts
+++ b/src/hooks/useCompanyBrain.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -50,7 +51,7 @@ export const useCompanyBrain = () => {
       setInsights(aiInsights);
       setDataStatus(status);
     } catch (error) {
-      console.error('Error loading company brain data:', error);
+      logger.error('Error loading company brain data:', error);
       toast.error('Failed to load company brain data');
     } finally {
       setIsLoading(false);
@@ -72,7 +73,7 @@ export const useCompanyBrain = () => {
       }
       return success;
     } catch (error) {
-      console.error('Error connecting social media:', error);
+      logger.error('Error connecting social media:', error);
       toast.error(`Failed to connect ${platform}`);
       return false;
     }
@@ -86,7 +87,7 @@ export const useCompanyBrain = () => {
       await loadData(); // Refresh data
       toast.success(`${platform} data synced successfully`);
     } catch (error) {
-      console.error('Error syncing social media:', error);
+      logger.error('Error syncing social media:', error);
       toast.error(`Failed to sync ${platform} data`);
     }
   }, [companyId, loadData]);
@@ -100,7 +101,7 @@ export const useCompanyBrain = () => {
       await loadData(); // Refresh data
       return uploaded;
     } catch (error) {
-      console.error('Error uploading files:', error);
+      logger.error('Error uploading files:', error);
       toast.error('Failed to upload files');
       return [];
     }
@@ -117,7 +118,7 @@ export const useCompanyBrain = () => {
       toast.success('Website crawled successfully');
       return data;
     } catch (error) {
-      console.error('Error crawling website:', error);
+      logger.error('Error crawling website:', error);
       toast.error('Failed to crawl website');
       return null;
     } finally {
@@ -134,7 +135,7 @@ export const useCompanyBrain = () => {
       setInsights(newInsights);
       toast.success('Insights refreshed');
     } catch (error) {
-      console.error('Error refreshing insights:', error);
+      logger.error('Error refreshing insights:', error);
       toast.error('Failed to refresh insights');
     }
   }, [companyId]);
@@ -147,7 +148,7 @@ export const useCompanyBrain = () => {
       toast.success('Campaign brief created');
       return brief;
     } catch (error) {
-      console.error('Error creating campaign brief:', error);
+      logger.error('Error creating campaign brief:', error);
       toast.error('Failed to create campaign brief');
       return '';
     }
@@ -172,7 +173,7 @@ Generated: ${insight.createdAt.toLocaleDateString()}
       navigator.clipboard.writeText(emailBody);
       toast.success('Email content copied to clipboard');
     } catch (error) {
-      console.error('Error preparing email:', error);
+      logger.error('Error preparing email:', error);
       toast.error('Failed to prepare email');
     }
   }, []);

--- a/src/hooks/useEmailConnection.ts
+++ b/src/hooks/useEmailConnection.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -54,7 +55,7 @@ export const useEmailConnection = () => {
         })));
       }
     } catch (error) {
-      console.error('Failed to fetch connection status:', error);
+      logger.error('Failed to fetch connection status:', error);
     }
   };
 
@@ -94,7 +95,7 @@ export const useEmailConnection = () => {
 
       // For demo purposes, we'll simulate a successful connection
       // In a real implementation, you would open the OAuth URL
-      console.log('OAuth URL:', authUrl);
+      logger.info('OAuth URL:', authUrl);
       
       // Simulate OAuth success
       setTimeout(() => {
@@ -109,7 +110,7 @@ export const useEmailConnection = () => {
       }, 2000);
 
     } catch (error) {
-      console.error('Failed to connect provider:', error);
+      logger.error('Failed to connect provider:', error);
       toast.error('Failed to connect email provider');
       setLoading(false);
     }
@@ -140,7 +141,7 @@ export const useEmailConnection = () => {
 
       toast.success('Email provider disconnected');
     } catch (error) {
-      console.error('Failed to disconnect provider:', error);
+      logger.error('Failed to disconnect provider:', error);
       toast.error('Failed to disconnect email provider');
     }
   };
@@ -160,7 +161,7 @@ export const useEmailConnection = () => {
       
       setEmails(data.emails || []);
     } catch (error) {
-      console.error('Failed to fetch emails:', error);
+      logger.error('Failed to fetch emails:', error);
       toast.error('Failed to fetch emails');
       
       // For demo purposes, provide mock emails

--- a/src/hooks/useEmailService.ts
+++ b/src/hooks/useEmailService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -45,7 +46,7 @@ export const useEmailService = () => {
       toast.success('Email sent successfully');
       return { success: true, data };
     } catch (error) {
-      console.error('Email send error:', error);
+      logger.error('Email send error:', error);
       toast.error('Failed to send email');
       return { success: false, error };
     } finally {
@@ -79,7 +80,7 @@ export const useEmailService = () => {
       toast.success('Email sequence started');
       return { success: true, data };
     } catch (error) {
-      console.error('Email sequence error:', error);
+      logger.error('Email sequence error:', error);
       toast.error('Failed to start email sequence');
       return { success: false, error };
     } finally {

--- a/src/hooks/useEnhancedUsageTracking.ts
+++ b/src/hooks/useEnhancedUsageTracking.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -80,7 +81,7 @@ export const useEnhancedUsageTracking = () => {
       if (error) throw error;
       
     } catch (error) {
-      console.error('Error tracking enhanced usage event:', error);
+      logger.error('Error tracking enhanced usage event:', error);
     } finally {
       setIsLogging(false);
     }
@@ -162,7 +163,7 @@ export const useEnhancedUsageTracking = () => {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error logging AI learning data:', error);
+      logger.error('Error logging AI learning data:', error);
     }
   };
 

--- a/src/hooks/useErrorBoundary.ts
+++ b/src/hooks/useErrorBoundary.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { useNotifications } from './useNotifications';
@@ -26,8 +27,8 @@ export const useErrorBoundary = () => {
 
     // Log to console in development
     if (import.meta.env.DEV) {
-      console.error('Application Error:', error);
-      console.error('Error Info:', errorInfo);
+      logger.error('Application Error:', error);
+      logger.error('Error Info:', errorInfo);
     }
 
     // Create user notification for critical errors

--- a/src/hooks/useGmailIntegration.ts
+++ b/src/hooks/useGmailIntegration.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -52,7 +53,7 @@ export const useGmailIntegration = () => {
       setConnectionStatus(status);
       return status;
     } catch (error) {
-      console.error('Failed to check Gmail connection:', error);
+      logger.error('Failed to check Gmail connection:', error);
       const status = {
         connected: false,
         message: 'Failed to check connection status',
@@ -119,7 +120,7 @@ export const useGmailIntegration = () => {
 
       return { success: false };
     } catch (error) {
-      console.error('Failed to connect Gmail:', error);
+      logger.error('Failed to connect Gmail:', error);
       toast.error('Failed to initiate Gmail connection');
       return { success: false };
     } finally {
@@ -159,7 +160,7 @@ export const useGmailIntegration = () => {
 
       throw new Error(data.error || 'Failed to send email');
     } catch (error: any) {
-      console.error('Failed to send email:', error);
+      logger.error('Failed to send email:', error);
       toast.error(error.message || 'Failed to send email');
       return { success: false, error: error.message };
     } finally {
@@ -200,7 +201,7 @@ export const useGmailIntegration = () => {
       toast.success('Gmail disconnected successfully');
       return { success: true };
     } catch (error) {
-      console.error('Failed to disconnect Gmail:', error);
+      logger.error('Failed to disconnect Gmail:', error);
       toast.error('Failed to disconnect Gmail');
       return { success: false };
     }

--- a/src/hooks/useIntegrations.ts
+++ b/src/hooks/useIntegrations.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -26,7 +27,7 @@ export const useIntegrations = () => {
 
       return { success: false, error: 'No auth URL received' };
     } catch (error) {
-      console.error('Gmail connection error:', error);
+      logger.error('Gmail connection error:', error);
       toast.error('Failed to connect Gmail');
       return { success: false, error };
     } finally {
@@ -68,7 +69,7 @@ export const useIntegrations = () => {
         emailId: data?.emailId 
       };
     } catch (error) {
-      console.error('Email send error:', error);
+      logger.error('Email send error:', error);
       toast.error('Failed to send email');
       return { success: false, error };
     } finally {
@@ -87,7 +88,7 @@ export const useIntegrations = () => {
     try {
       // For now, we'll simulate a call initiation
       // In a real implementation, this would connect to Twilio or similar service
-      console.log(`Initiating call to ${phoneNumber} for lead ${leadName}`);
+      logger.info(`Initiating call to ${phoneNumber} for lead ${leadName}`);
       
       // Log the call attempt
       await supabase.from('usage_events').insert({
@@ -107,7 +108,7 @@ export const useIntegrations = () => {
         callSid 
       };
     } catch (error) {
-      console.error('Call initiation error:', error);
+      logger.error('Call initiation error:', error);
       toast.error('Failed to initiate call');
       return { success: false, error };
     } finally {
@@ -126,7 +127,7 @@ export const useIntegrations = () => {
     try {
       // For now, we'll simulate SMS sending
       // In a real implementation, this would connect to Twilio SMS service
-      console.log(`Sending SMS to ${phoneNumber}: ${message}`);
+      logger.info(`Sending SMS to ${phoneNumber}: ${message}`);
       
       // Log the SMS attempt
       await supabase.from('usage_events').insert({
@@ -146,7 +147,7 @@ export const useIntegrations = () => {
         messageSid 
       };
     } catch (error) {
-      console.error('SMS send error:', error);
+      logger.error('SMS send error:', error);
       toast.error('Failed to send SMS');
       return { success: false, error };
     } finally {
@@ -165,7 +166,7 @@ export const useIntegrations = () => {
     try {
       // For now, we'll simulate calendar event creation
       // In a real implementation, this would connect to Google Calendar API
-      console.log(`Scheduling calendar event for ${leadName}:`, eventDetails);
+      logger.info(`Scheduling calendar event for ${leadName}:`, eventDetails);
       
       // Log the calendar event attempt
       await supabase.from('usage_events').insert({
@@ -185,7 +186,7 @@ export const useIntegrations = () => {
         eventId 
       };
     } catch (error) {
-      console.error('Calendar event error:', error);
+      logger.error('Calendar event error:', error);
       toast.error('Failed to schedule meeting');
       return { success: false, error };
     } finally {

--- a/src/hooks/useKnowledgeIngest.ts
+++ b/src/hooks/useKnowledgeIngest.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from "@/integrations/supabase/client";
@@ -45,12 +46,12 @@ export function useKnowledgeIngest() {
           .single();
         
         if (profileError) {
-          console.error("Error fetching user's company_id:", profileError);
+          logger.error("Error fetching user's company_id:", profileError);
         } else if (profileData) {
           companyId = profileData.company_id;
         }
       } catch (err) {
-        console.error("Exception when fetching user's company_id:", err);
+        logger.error("Exception when fetching user's company_id:", err);
       }
     }
 
@@ -69,7 +70,7 @@ export function useKnowledgeIngest() {
       });
 
       if (error) {
-        console.error("Error ingesting to AI Brain:", error);
+        logger.error("Error ingesting to AI Brain:", error);
         setError(error.message || "Error communicating with AI Brain");
         toast.error("Failed to ingest data to AI Brain");
         return null;
@@ -79,7 +80,7 @@ export function useKnowledgeIngest() {
       return data;
       
     } catch (err: any) {
-      console.error("Exception when ingesting to AI Brain:", err);
+      logger.error("Exception when ingesting to AI Brain:", err);
       setError(err.message || "Unknown error occurred");
       toast.error("Failed to ingest data");
       return null;
@@ -110,12 +111,12 @@ export function useKnowledgeIngest() {
         .single();
       
       if (profileError) {
-        console.error("Error fetching user's company_id:", profileError);
+        logger.error("Error fetching user's company_id:", profileError);
       } else if (profileData) {
         companyId = profileData.company_id;
       }
     } catch (err) {
-      console.error("Exception when fetching user's company_id:", err);
+      logger.error("Exception when fetching user's company_id:", err);
     }
 
     setIsIngesting(true);
@@ -133,7 +134,7 @@ export function useKnowledgeIngest() {
       });
 
       if (error) {
-        console.error("Error crawling web content:", error);
+        logger.error("Error crawling web content:", error);
         setError(error.message || "Error crawling web content");
         toast.error("Failed to crawl web content");
         return null;
@@ -143,7 +144,7 @@ export function useKnowledgeIngest() {
       return data;
       
     } catch (err: any) {
-      console.error("Exception when crawling web content:", err);
+      logger.error("Exception when crawling web content:", err);
       setError(err.message || "Unknown error occurred");
       toast.error("Failed to crawl web content");
       return null;

--- a/src/hooks/useKnowledgeManagement.ts
+++ b/src/hooks/useKnowledgeManagement.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from "@/integrations/supabase/client";
@@ -24,7 +25,7 @@ export function useKnowledgeManagement() {
         .eq('id', id);
 
       if (error) {
-        console.error("Error deleting knowledge entry:", error);
+        logger.error("Error deleting knowledge entry:", error);
         toast.error("Failed to delete knowledge entry");
         return false;
       }
@@ -33,7 +34,7 @@ export function useKnowledgeManagement() {
       return true;
       
     } catch (err: any) {
-      console.error("Exception when deleting knowledge entry:", err);
+      logger.error("Exception when deleting knowledge entry:", err);
       toast.error("Failed to delete knowledge entry");
       return false;
     }
@@ -65,7 +66,7 @@ export function useKnowledgeManagement() {
         .eq('id', id);
 
       if (error) {
-        console.error("Error marking as case study:", error);
+        logger.error("Error marking as case study:", error);
         toast.error("Failed to mark as case study");
         return false;
       }
@@ -74,7 +75,7 @@ export function useKnowledgeManagement() {
       return true;
       
     } catch (err: any) {
-      console.error("Exception when marking as case study:", err);
+      logger.error("Exception when marking as case study:", err);
       toast.error("Failed to mark as case study");
       return false;
     }

--- a/src/hooks/useKnowledgeQuery.ts
+++ b/src/hooks/useKnowledgeQuery.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from "@/integrations/supabase/client";
@@ -43,12 +44,12 @@ export function useKnowledgeQuery() {
           .single();
         
         if (profileError) {
-          console.error("Error fetching user's company_id:", profileError);
+          logger.error("Error fetching user's company_id:", profileError);
         } else if (profileData) {
           companyId = profileData.company_id;
         }
       } catch (err) {
-        console.error("Exception when fetching user's company_id:", err);
+        logger.error("Exception when fetching user's company_id:", err);
       }
     }
 
@@ -66,7 +67,7 @@ export function useKnowledgeQuery() {
       });
 
       if (error) {
-        console.error("Error querying AI Brain:", error);
+        logger.error("Error querying AI Brain:", error);
         setError(error.message || "Error communicating with AI Brain");
         toast.error("Failed to query AI Brain");
         return null;
@@ -87,7 +88,7 @@ export function useKnowledgeQuery() {
       return results;
       
     } catch (err: any) {
-      console.error("Exception when querying AI Brain:", err);
+      logger.error("Exception when querying AI Brain:", err);
       setError(err.message || "Unknown error occurred");
       toast.error("Failed to query AI Brain");
       return null;

--- a/src/hooks/useKnowledgeReindex.ts
+++ b/src/hooks/useKnowledgeReindex.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from "@/integrations/supabase/client";
@@ -28,7 +29,7 @@ export function useKnowledgeReindex() {
       const { data, error } = await supabase.functions.invoke('ai-brain-reindex');
 
       if (error) {
-        console.error("Error reindexing AI Brain:", error);
+        logger.error("Error reindexing AI Brain:", error);
         setError(error.message || "Error reindexing AI Brain data");
         toast.error("Failed to reindex AI Brain data");
         return null;
@@ -44,7 +45,7 @@ export function useKnowledgeReindex() {
       return data;
       
     } catch (err: any) {
-      console.error("Exception when reindexing AI Brain:", err);
+      logger.error("Exception when reindexing AI Brain:", err);
       setError(err.message || "Unknown error occurred");
       toast.error("Failed to reindex data");
       return null;

--- a/src/hooks/useLeadImport.ts
+++ b/src/hooks/useLeadImport.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -222,7 +223,7 @@ export const useLeadImport = () => {
       toast.success('Import session created');
       return session;
     } catch (error) {
-      console.error('Error creating import session:', error);
+      logger.error('Error creating import session:', error);
       toast.error('Failed to create import session');
       return null;
     } finally {
@@ -261,7 +262,7 @@ export const useLeadImport = () => {
       toast.success(`${rawData.length} records uploaded for processing`);
       return true;
     } catch (error) {
-      console.error('Error uploading raw data:', error);
+      logger.error('Error uploading raw data:', error);
       toast.error('Failed to upload data');
       return false;
     } finally {
@@ -288,7 +289,7 @@ export const useLeadImport = () => {
       toast.success('Field mapping saved');
       return true;
     } catch (error) {
-      console.error('Error saving field mapping:', error);
+      logger.error('Error saving field mapping:', error);
       toast.error('Failed to save field mapping');
       return false;
     } finally {
@@ -447,7 +448,7 @@ export const useLeadImport = () => {
 
           successCount++;
         } catch (error: any) {
-          console.error('Error importing record:', error);
+          logger.error('Error importing record:', error);
           
           // Update raw data with error
           await supabase
@@ -516,7 +517,7 @@ export const useLeadImport = () => {
       toast.success(`Import completed: ${successCount} leads imported, ${errorCount} errors`);
       return true;
     } catch (error: any) {
-      console.error('Error processing import:', error);
+      logger.error('Error processing import:', error);
       
       // Update session with error
       await supabase
@@ -704,7 +705,7 @@ export const useLeadImport = () => {
 
       setImportSessions(sessions);
     } catch (error) {
-      console.error('Error fetching import sessions:', error);
+      logger.error('Error fetching import sessions:', error);
       toast.error('Failed to fetch import history');
     } finally {
       setIsLoading(false);

--- a/src/hooks/useLeads.ts
+++ b/src/hooks/useLeads.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -29,7 +30,7 @@ export const useLeads = () => {
       const convertedLeads = data?.map(convertDatabaseLeadToLead) || [];
       setLeads(convertedLeads);
     } catch (err) {
-      console.error('Error fetching leads:', err);
+      logger.error('Error fetching leads:', err);
       setError(err instanceof Error ? err.message : 'Failed to fetch leads');
     } finally {
       setIsLoading(false);

--- a/src/hooks/useManagerAI.ts
+++ b/src/hooks/useManagerAI.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { masterAIBrain, AIRecommendation } from '@/services/masterAIBrain';
@@ -74,7 +75,7 @@ export const useManagerAI = () => {
       });
 
     } catch (error) {
-      console.error('Error getting contextual insights:', error);
+      logger.error('Error getting contextual insights:', error);
       toast.error('Failed to generate insights');
     } finally {
       setIsGenerating(false);
@@ -219,7 +220,7 @@ export const useManagerAI = () => {
       return data.response;
 
     } catch (error) {
-      console.error('Error generating manager report:', error);
+      logger.error('Error generating manager report:', error);
       toast.error('Failed to generate report');
       return null;
     } finally {
@@ -243,7 +244,7 @@ export const useManagerAI = () => {
         timestamp: new Date().toISOString()
       };
     } catch (error) {
-      console.error('Error gathering report data:', error);
+      logger.error('Error gathering report data:', error);
       return {};
     }
   };
@@ -298,7 +299,7 @@ export const useManagerAI = () => {
       return newSequence;
 
     } catch (error) {
-      console.error('Error creating automation sequence:', error);
+      logger.error('Error creating automation sequence:', error);
       toast.error('Failed to create automation sequence');
       return null;
     }
@@ -341,7 +342,7 @@ export const useManagerAI = () => {
       return data.response;
 
     } catch (error) {
-      console.error('Error asking Jarvis:', error);
+      logger.error('Error asking Jarvis:', error);
       toast.error('Failed to get response from Jarvis');
       return null;
     } finally {
@@ -364,7 +365,7 @@ export const useManagerAI = () => {
         timestamp: new Date().toISOString()
       };
     } catch (error) {
-      console.error('Error getting manager context:', error);
+      logger.error('Error getting manager context:', error);
       return {};
     }
   };
@@ -378,7 +379,7 @@ export const useManagerAI = () => {
 
       return data || [];
     } catch (error) {
-      console.error('Error getting team stats:', error);
+      logger.error('Error getting team stats:', error);
       return [];
     }
   };
@@ -394,7 +395,7 @@ export const useManagerAI = () => {
 
       return data || [];
     } catch (error) {
-      console.error('Error getting recent insights:', error);
+      logger.error('Error getting recent insights:', error);
       return [];
     }
   };
@@ -414,7 +415,7 @@ export const useManagerAI = () => {
 
       return metrics;
     } catch (error) {
-      console.error('Error getting company metrics:', error);
+      logger.error('Error getting company metrics:', error);
       return {};
     }
   };

--- a/src/hooks/useMonthlyFeedback.ts
+++ b/src/hooks/useMonthlyFeedback.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -55,7 +56,7 @@ export const useMonthlyFeedback = () => {
         await generateMonthlyFeedback(settings.original_goal);
       }
     } catch (error) {
-      console.error('Error checking feedback schedule:', error);
+      logger.error('Error checking feedback schedule:', error);
     } finally {
       setIsLoading(false);
     }
@@ -172,7 +173,7 @@ export const useMonthlyFeedback = () => {
       });
       
     } catch (error) {
-      console.error('Error generating monthly feedback:', error);
+      logger.error('Error generating monthly feedback:', error);
     } finally {
       setIsLoading(false);
     }
@@ -214,7 +215,7 @@ export const useMonthlyFeedback = () => {
       setFeedbackReady(false);
       
     } catch (error) {
-      console.error('Error accepting suggestions:', error);
+      logger.error('Error accepting suggestions:', error);
       toast.error('Failed to process feedback suggestions');
     } finally {
       setIsLoading(false);

--- a/src/hooks/useNativeAutomation.ts
+++ b/src/hooks/useNativeAutomation.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -112,7 +113,7 @@ export const useNativeAutomation = () => {
 
       await emailAutomationService.evaluateAutomationTriggers(trigger, enrichedEventData);
     } catch (error) {
-      console.error('Error triggering automation:', error);
+      logger.error('Error triggering automation:', error);
     }
   }, [user?.id, profile?.company_id]);
 

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -35,7 +36,7 @@ export const useNotifications = () => {
       if (error) throw error;
       setNotifications(data || []);
     } catch (error) {
-      console.error('Error fetching notifications:', error);
+      logger.error('Error fetching notifications:', error);
     } finally {
       setIsLoading(false);
     }
@@ -63,7 +64,7 @@ export const useNotifications = () => {
       setNotifications(prev => [data, ...prev]);
       toast.info(notification.title, { description: notification.message });
     } catch (error) {
-      console.error('Error creating notification:', error);
+      logger.error('Error creating notification:', error);
     }
   };
 
@@ -80,7 +81,7 @@ export const useNotifications = () => {
         prev.map(n => n.id === notificationId ? { ...n, is_read: true } : n)
       );
     } catch (error) {
-      console.error('Error marking notification as read:', error);
+      logger.error('Error marking notification as read:', error);
     }
   };
 
@@ -100,7 +101,7 @@ export const useNotifications = () => {
         prev.map(n => ({ ...n, is_read: true }))
       );
     } catch (error) {
-      console.error('Error marking all notifications as read:', error);
+      logger.error('Error marking all notifications as read:', error);
     }
   };
 

--- a/src/hooks/usePerformanceMonitor.tsx
+++ b/src/hooks/usePerformanceMonitor.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useEffect, useRef } from 'react';
 import { useUsageTracking } from './useUsageTracking';
@@ -40,7 +41,7 @@ export const usePerformanceMonitor = (componentName: string) => {
 
     // Monitor for performance issues
     if (loadTime > 2000) {
-      console.warn(`Slow component load detected: ${componentName} took ${loadTime}ms`);
+      logger.warn(`Slow component load detected: ${componentName} took ${loadTime}ms`);
       trackEvent({
         feature: 'performance_issue',
         action: 'slow_load',
@@ -50,7 +51,7 @@ export const usePerformanceMonitor = (componentName: string) => {
     }
 
     if (renderTime > 500) {
-      console.warn(`Slow component render detected: ${componentName} took ${renderTime}ms`);
+      logger.warn(`Slow component render detected: ${componentName} took ${renderTime}ms`);
       trackEvent({
         feature: 'performance_issue',
         action: 'slow_render',

--- a/src/hooks/useSalesRepAI.ts
+++ b/src/hooks/useSalesRepAI.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -83,7 +84,7 @@ export const useSalesRepAI = () => {
       });
 
     } catch (error) {
-      console.error('Error getting personalized recommendations:', error);
+      logger.error('Error getting personalized recommendations:', error);
       toast.error('Failed to generate recommendations');
     } finally {
       setIsGenerating(false);
@@ -152,7 +153,7 @@ export const useSalesRepAI = () => {
       return recommendations;
 
     } catch (error) {
-      console.error('Error generating task recommendations:', error);
+      logger.error('Error generating task recommendations:', error);
       return [];
     }
   };
@@ -217,7 +218,7 @@ export const useSalesRepAI = () => {
       return coaching;
 
     } catch (error) {
-      console.error('Error generating coaching recommendations:', error);
+      logger.error('Error generating coaching recommendations:', error);
       return [];
     }
   };
@@ -268,7 +269,7 @@ export const useSalesRepAI = () => {
       return insights;
 
     } catch (error) {
-      console.error('Error generating performance insights:', error);
+      logger.error('Error generating performance insights:', error);
       return [];
     }
   };
@@ -285,7 +286,7 @@ export const useSalesRepAI = () => {
 
       return data || [];
     } catch (error) {
-      console.error('Error getting user leads:', error);
+      logger.error('Error getting user leads:', error);
       return [];
     }
   };
@@ -301,7 +302,7 @@ export const useSalesRepAI = () => {
 
       return data || [];
     } catch (error) {
-      console.error('Error getting call history:', error);
+      logger.error('Error getting call history:', error);
       return [];
     }
   };
@@ -316,7 +317,7 @@ export const useSalesRepAI = () => {
 
       return data;
     } catch (error) {
-      console.error('Error getting user stats:', error);
+      logger.error('Error getting user stats:', error);
       return null;
     }
   };
@@ -383,7 +384,7 @@ export const useSalesRepAI = () => {
       return data.response;
 
     } catch (error) {
-      console.error('Error asking coach:', error);
+      logger.error('Error asking coach:', error);
       toast.error('Failed to get response from coach');
       return null;
     } finally {
@@ -407,7 +408,7 @@ export const useSalesRepAI = () => {
         timestamp: new Date().toISOString()
       };
     } catch (error) {
-      console.error('Error getting rep context:', error);
+      logger.error('Error getting rep context:', error);
       return {};
     }
   };

--- a/src/hooks/useUnifiedOAuth.ts
+++ b/src/hooks/useUnifiedOAuth.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect, useCallback } from 'react';
 import { unifiedOAuthService, OAuthProvider, OAuthConnectionStatus } from '@/services/oauth/unifiedOAuthService';
@@ -23,7 +24,7 @@ export const useUnifiedOAuth = () => {
         const status = await unifiedOAuthService.checkConnectionStatus(provider.id);
         statuses[provider.id] = status;
       } catch (error) {
-        console.error(`Failed to check ${provider.id} status:`, error);
+        logger.error(`Failed to check ${provider.id} status:`, error);
         statuses[provider.id] = { provider: provider.id, connected: false };
       }
     }

--- a/src/hooks/useUnusedFeatures.ts
+++ b/src/hooks/useUnusedFeatures.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -33,7 +34,7 @@ export const useUnusedFeatures = () => {
       setUnusedFeatures(data || []);
       
     } catch (error) {
-      console.error('Error fetching unused features:', error);
+      logger.error('Error fetching unused features:', error);
     } finally {
       setIsLoading(false);
     }
@@ -73,7 +74,7 @@ export const useUnusedFeatures = () => {
       }
       
     } catch (error) {
-      console.error('Error updating feature usage:', error);
+      logger.error('Error updating feature usage:', error);
     }
   };
 
@@ -89,7 +90,7 @@ export const useUnusedFeatures = () => {
       fetchUnusedFeatures();
       
     } catch (error) {
-      console.error('Error flagging feature:', error);
+      logger.error('Error flagging feature:', error);
     }
   };
 

--- a/src/hooks/useUsageTracking.ts
+++ b/src/hooks/useUsageTracking.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -38,7 +39,7 @@ export const useUsageTracking = () => {
       if (error) throw error;
       
     } catch (error) {
-      console.error('Error tracking usage event:', error);
+      logger.error('Error tracking usage event:', error);
     } finally {
       setIsLogging(false);
     }

--- a/src/hooks/useVoiceCommands.ts
+++ b/src/hooks/useVoiceCommands.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useCallback } from 'react';
 import { voiceService } from '@/services/ai/voiceService';
@@ -33,10 +34,10 @@ export const useVoiceCommands = (options: UseVoiceCommandsOptions = {}) => {
         return false;
       }
 
-      console.log('Voice recording started successfully');
+      logger.info('Voice recording started successfully');
       return true;
     } catch (error) {
-      console.error('Error starting voice commands:', error);
+      logger.error('Error starting voice commands:', error);
       setIsListening(false);
       const errorMessage = error instanceof Error ? error.message : 'Voice recording failed';
       options.onError?.(errorMessage);
@@ -49,7 +50,7 @@ export const useVoiceCommands = (options: UseVoiceCommandsOptions = {}) => {
       setIsListening(false);
       setIsProcessing(true);
 
-      console.log('Stopping voice recording...');
+      logger.info('Stopping voice recording...');
       const audioBlob = await voiceService.stopRecording();
       
       if (!audioBlob || audioBlob.size === 0) {
@@ -59,11 +60,11 @@ export const useVoiceCommands = (options: UseVoiceCommandsOptions = {}) => {
         return null;
       }
 
-      console.log('Processing voice command...');
+      logger.info('Processing voice command...');
       const transcription = await voiceService.processAudioCommand(audioBlob, 'current-user');
       
       if (transcription && transcription.trim()) {
-        console.log('Voice command transcribed:', transcription);
+        logger.info('Voice command transcribed:', transcription);
         setLastTranscription(transcription);
         options.onCommand?.(transcription);
         toast.success('Voice command processed successfully');
@@ -75,7 +76,7 @@ export const useVoiceCommands = (options: UseVoiceCommandsOptions = {}) => {
       }
 
     } catch (error) {
-      console.error('Error processing voice command:', error);
+      logger.error('Error processing voice command:', error);
       const errorMessage = error instanceof Error ? error.message : 'Voice processing failed';
       options.onError?.(errorMessage);
       return null;
@@ -96,14 +97,14 @@ export const useVoiceCommands = (options: UseVoiceCommandsOptions = {}) => {
     try {
       // Ensure text is a string and not empty
       if (!text || typeof text !== 'string') {
-        console.error('Invalid text provided to speakResponse:', text);
+        logger.error('Invalid text provided to speakResponse:', text);
         throw new Error('Invalid text provided for speech');
       }
 
-      console.log('Speaking response:', text.substring(0, 50) + '...');
+      logger.info('Speaking response:', text.substring(0, 50) + '...');
       await voiceService.generateVoiceResponse(text);
     } catch (error) {
-      console.error('Error speaking response:', error);
+      logger.error('Error speaking response:', error);
       // Fallback to toast notification with safe string handling
       const fallbackText = typeof text === 'string' ? text : 'AI response generated';
       const truncatedText = fallbackText.substring(0, 100);

--- a/src/hooks/useVoicePermissions.ts
+++ b/src/hooks/useVoicePermissions.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
@@ -43,7 +44,7 @@ export const useVoicePermissions = () => {
           await checkMicrophonePermission();
         }
       } catch (error) {
-        console.error('Error checking voice capabilities:', error);
+        logger.error('Error checking voice capabilities:', error);
         setState(prev => ({
           ...prev,
           error: 'Failed to check voice capabilities'
@@ -67,7 +68,7 @@ export const useVoicePermissions = () => {
         };
       }
     } catch (error) {
-      console.warn('Could not check microphone permission:', error);
+      logger.warn('Could not check microphone permission:', error);
       setState(prev => ({ ...prev, permissionState: 'unknown' }));
     }
   };
@@ -95,7 +96,7 @@ export const useVoicePermissions = () => {
       return true;
       
     } catch (error: any) {
-      console.error('Microphone permission denied:', error);
+      logger.error('Microphone permission denied:', error);
       
       let errorMessage = 'Microphone access denied. ';
       

--- a/src/hooks/voice/useAudioProcessing.ts
+++ b/src/hooks/voice/useAudioProcessing.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useRef, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -26,7 +27,7 @@ export const useAudioProcessing = () => {
       return true;
 
     } catch (error: any) {
-      console.error('Error starting audio recording:', error);
+      logger.error('Error starting audio recording:', error);
       
       if (error.name === 'NotAllowedError') {
         toast.error('Microphone access denied. Please allow microphone access and try again.');
@@ -72,7 +73,7 @@ export const useAudioProcessing = () => {
 
       return transcriptionData.text;
     } catch (error) {
-      console.error('Error processing audio command:', error);
+      logger.error('Error processing audio command:', error);
       throw error;
     }
   }, []);
@@ -89,7 +90,7 @@ export const useAudioProcessing = () => {
         });
       }
     } catch (error) {
-      console.error('Error generating voice response:', error);
+      logger.error('Error generating voice response:', error);
     }
   }, []);
 

--- a/src/hooks/voice/useSpeechRecognition.ts
+++ b/src/hooks/voice/useSpeechRecognition.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { useRef, useCallback } from 'react';
 import { SpeechRecognition } from './types';
@@ -30,7 +31,7 @@ export const useSpeechRecognition = () => {
     }
   ) => {
     recognition.onstart = () => {
-      console.log('Speech recognition started');
+      logger.info('Speech recognition started');
       handlers.onStart();
     };
 
@@ -43,7 +44,7 @@ export const useSpeechRecognition = () => {
     };
 
     recognition.onerror = (event) => {
-      console.error('Speech recognition error:', event.error);
+      logger.error('Speech recognition error:', event.error);
       
       let errorMessage = 'Speech recognition error: ';
       
@@ -68,7 +69,7 @@ export const useSpeechRecognition = () => {
     };
 
     recognition.onend = () => {
-      console.log('Speech recognition ended');
+      logger.info('Speech recognition ended');
       handlers.onEnd();
     };
   }, []);
@@ -79,7 +80,7 @@ export const useSpeechRecognition = () => {
         recognitionRef.current.start();
         return true;
       } catch (error) {
-        console.error('Failed to start speech recognition:', error);
+        logger.error('Failed to start speech recognition:', error);
         return false;
       }
     }
@@ -91,7 +92,7 @@ export const useSpeechRecognition = () => {
       try {
         recognitionRef.current.stop();
       } catch (error) {
-        console.error('Error stopping recognition:', error);
+        logger.error('Error stopping recognition:', error);
       }
     }
   }, []);

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { createClient } from '@supabase/supabase-js';
 
@@ -5,7 +6,7 @@ const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 if (!supabaseUrl || !supabaseKey) {
-  console.warn('Supabase credentials not found, using demo mode');
+  logger.warn('Supabase credentials not found, using demo mode');
 }
 
 export const supabase = createClient(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
@@ -9,7 +10,7 @@ import { optimizeForMobile } from './utils/mobileOptimization';
 try {
   optimizeForMobile();
 } catch (error) {
-  console.warn('Mobile optimization failed:', error);
+  logger.warn('Mobile optimization failed:', error);
 }
 
 // Performance monitoring
@@ -17,12 +18,12 @@ if (process.env.NODE_ENV === 'development') {
   try {
     const observer = new PerformanceObserver((list) => {
       list.getEntries().forEach((entry) => {
-        console.log(`Performance: ${entry.name} - ${entry.duration}ms`);
+        logger.info(`Performance: ${entry.name} - ${entry.duration}ms`);
       });
     });
     observer.observe({ entryTypes: ['measure', 'navigation'] });
   } catch (error) {
-    console.warn('Performance monitoring failed:', error);
+    logger.warn('Performance monitoring failed:', error);
   }
 }
 
@@ -40,9 +41,9 @@ try {
       <App />
     </React.StrictMode>
   );
-  console.log('App rendered successfully');
+  logger.info('App rendered successfully');
 } catch (error) {
-  console.error('Failed to render app:', error);
+  logger.error('Failed to render app:', error);
   // Render a simple error message
   root.render(
     <div style={{ padding: '20px', textAlign: 'center' }}>
@@ -61,10 +62,10 @@ if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js')
       .then((registration) => {
-        console.log('SW registered: ', registration);
+        logger.info('SW registered: ', registration);
       })
       .catch((registrationError) => {
-        console.log('SW registration failed: ', registrationError);
+        logger.info('SW registration failed: ', registrationError);
       });
   });
 }

--- a/src/pages/LeadManagement.tsx
+++ b/src/pages/LeadManagement.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -26,7 +27,7 @@ const LeadManagement = () => {
     const hasReal = realLeads.length > 0;
     const shouldShowDemo = isDemo || (!hasReal);
     
-    console.log('LeadManagement state:', {
+    logger.info('LeadManagement state:', {
       isDemo,
       hasReal,
       shouldShowDemo,
@@ -52,7 +53,7 @@ const LeadManagement = () => {
   }, [realLeads, mockLeads, isDemoMode]);
 
   const handleLeadSelect = (lead: Lead) => {
-    console.log('Lead selected:', lead);
+    logger.info('Lead selected:', lead);
     setSelectedLead(lead);
     setIsIntelligencePanelOpen(true);
     setIsSlidePanelOpen(true);

--- a/src/pages/LeadWorkspace.tsx
+++ b/src/pages/LeadWorkspace.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
@@ -24,21 +25,21 @@ const LeadWorkspace: React.FC = () => {
   
   const [activeTab, setActiveTab] = useState('overview');
 
-  console.log('LeadWorkspace rendering with leadId:', leadId);
+  logger.info('LeadWorkspace rendering with leadId:', leadId);
 
   // Find the lead from either mock data or database
   const lead: Lead | null = useMemo(() => {
     if (!leadId) {
-      console.log('No leadId provided');
+      logger.info('No leadId provided');
       return null;
     }
 
     const isDemo = isDemoMode();
-    console.log('LeadWorkspace: Demo mode:', isDemo);
+    logger.info('LeadWorkspace: Demo mode:', isDemo);
     
     if (isDemo) {
       // For demo mode, always use the mock lead profile regardless of which lead was clicked
-      console.log('Using mock lead profile for demo mode');
+      logger.info('Using mock lead profile for demo mode');
       return {
         ...mockLeadProfile,
         id: leadId // Keep the original ID so routing works
@@ -49,13 +50,13 @@ const LeadWorkspace: React.FC = () => {
     if (databaseLeads && databaseLeads.length > 0) {
       const dbLead = databaseLeads.find((l) => l.id === leadId);
       if (dbLead) {
-        console.log('Found database lead:', dbLead.name);
+        logger.info('Found database lead:', dbLead.name);
         return convertDatabaseLeadToLead(dbLead);
       }
     }
 
     // Fallback to mock profile for any lead when no database leads exist
-    console.log('Fallback to mock lead profile');
+    logger.info('Fallback to mock lead profile');
     return {
       ...mockLeadProfile,
       id: leadId
@@ -123,7 +124,7 @@ const LeadWorkspace: React.FC = () => {
               <div className="w-80 border-r border-gray-200 bg-white">
                 <LeadWorkspaceLeft 
                   lead={leadAsDbLead} 
-                  onQuickAction={(action: string) => console.log('Quick action:', action)}
+                  onQuickAction={(action: string) => logger.info('Quick action:', action)}
                   collapsed={false}
                   onToggleCollapse={() => {}}
                 />

--- a/src/pages/ManagerDashboard.tsx
+++ b/src/pages/ManagerDashboard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
@@ -217,7 +218,7 @@ const ManagerDashboard = () => {
           .single();
           
         if (statsError && statsError.code !== 'PGRST116') { // PGRST116 is "no rows returned" error
-          console.error('Error fetching stats for user', profile.id, statsError);
+          logger.error('Error fetching stats for user', profile.id, statsError);
           continue;
         }
         
@@ -244,7 +245,7 @@ const ManagerDashboard = () => {
       setRecommendations([]);
       
     } catch (error) {
-      console.error('Error fetching data:', error);
+      logger.error('Error fetching data:', error);
       toast.error('Failed to load dashboard data');
     } finally {
       setLoading(false);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from "react";
 import { useLocation, Link } from "react-router-dom";
@@ -11,7 +12,7 @@ const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
+    logger.error(
       "404 Error: User attempted to access non-existent route:",
       location.pathname
     );

--- a/src/pages/OnboardingTest.tsx
+++ b/src/pages/OnboardingTest.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -17,7 +18,7 @@ const OnboardingTest: React.FC = () => {
       <OnboardingProvider
         initialCompanyId="test-company-id"
         completeOnboardingFn={async (settings) => {
-          console.log('Test onboarding completed:', settings);
+          logger.info('Test onboarding completed:', settings);
           alert('Test onboarding completed! Check console for details.');
           setShowOnboarding(false);
         }}

--- a/src/pages/SalesRepDashboard.tsx
+++ b/src/pages/SalesRepDashboard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -32,7 +33,7 @@ const SalesRepDashboard = () => {
           .single();
         setUserStats(data);
       } catch (error) {
-        console.log('No user stats found, using defaults');
+        logger.info('No user stats found, using defaults');
       }
     };
 
@@ -116,7 +117,7 @@ const SalesRepDashboard = () => {
   ];
 
   const handleActionClick = (actionId: string) => {
-    console.log('Action clicked:', actionId);
+    logger.info('Action clicked:', actionId);
   };
 
   return (

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -37,7 +38,7 @@ const AuthPage = () => {
 
   // Redirect if already logged in
   if (user && profile && !isTransitioning) {
-    console.log("AuthPage: User is logged in, redirecting based on role:", profile.role);
+    logger.info("AuthPage: User is logged in, redirecting based on role:", profile.role);
     const redirectPath = profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
     const from = location.state?.from?.pathname || redirectPath;
     return <Navigate to={from} replace />;
@@ -48,13 +49,13 @@ const AuthPage = () => {
     const demoRole = localStorage.getItem('demoRole') as Role | null;
     if (demoRole) {
       const redirectPath = demoRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
-      console.log("AuthPage: Demo mode active, redirecting to", redirectPath);
+      logger.info("AuthPage: Demo mode active, redirecting to", redirectPath);
       return <Navigate to={redirectPath} replace />;
     }
   }
 
   const handleRoleChange = (role: Role) => {
-    console.log("AuthPage: Role changed to", role);
+    logger.info("AuthPage: Role changed to", role);
     setSelectedRole(role);
     setLastSelectedRole(role);
   };
@@ -64,7 +65,7 @@ const AuthPage = () => {
     // Simulate loading and transition to dashboard
     setTimeout(() => {
       const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
-      console.log("AuthPage: Transitioning to", redirectPath);
+      logger.info("AuthPage: Transitioning to", redirectPath);
       navigate(redirectPath, { replace: true });
       setIsTransitioning(false);
     }, 1500);

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React from 'react';
 import { Role } from '@/contexts/auth/types';
@@ -31,13 +32,13 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
   
   const handleDirectDemoLogin = () => {
     // Skip the form and directly log in with demo mode
-    console.log("Direct demo login with role:", selectedRole);
+    logger.info("Direct demo login with role:", selectedRole);
     initializeDemoMode(selectedRole);
     setIsTransitioning(true);
     
     // Direct navigation based on role - using correct existing routes
     const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
-    console.log("Redirecting to:", redirectPath);
+    logger.info("Redirecting to:", redirectPath);
     
     setTimeout(() => {
       navigate(redirectPath);

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -74,7 +75,7 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
         companyId: profileData.company_id
       };
     } catch (error) {
-      console.error('Error checking company settings:', error);
+      logger.error('Error checking company settings:', error);
       return null;
     }
   };
@@ -84,7 +85,7 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
     setIsLoading(true);
     
     try {
-      console.log('Logging in as full paying user');
+      logger.info('Logging in as full paying user');
       
       // Simulate full user authentication with all features unlocked
       initializeDemoMode('sales_rep');
@@ -120,7 +121,7 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
       return;
       
     } catch (error: any) {
-      console.error('Authentication error:', error);
+      logger.error('Authentication error:', error);
       toast.error(error.message || 'Login failed');
     } finally {
       setIsLoading(false);

--- a/src/pages/developer/AIBrainLogs.tsx
+++ b/src/pages/developer/AIBrainLogs.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -65,7 +66,7 @@ const AIBrainLogs: React.FC = () => {
       ];
       setLogs(mockLogs);
     } catch (error) {
-      console.error('Error fetching AI logs:', error);
+      logger.error('Error fetching AI logs:', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/developer/APILogs.tsx
+++ b/src/pages/developer/APILogs.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -75,7 +76,7 @@ const APILogs: React.FC = () => {
       ];
       setLogs(mockLogs);
     } catch (error) {
-      console.error('Error fetching API logs:', error);
+      logger.error('Error fetching API logs:', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/developer/ErrorLogs.tsx
+++ b/src/pages/developer/ErrorLogs.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -71,7 +72,7 @@ const ErrorLogs: React.FC = () => {
       ];
       setLogs(mockLogs);
     } catch (error) {
-      console.error('Error fetching error logs:', error);
+      logger.error('Error fetching error logs:', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/developer/Settings.tsx
+++ b/src/pages/developer/Settings.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -18,7 +19,7 @@ const Settings: React.FC = () => {
   const [cacheStrategy, setCacheStrategy] = useState('aggressive');
 
   const saveSettings = () => {
-    console.log('Saving developer settings...');
+    logger.info('Saving developer settings...');
     // In real app, this would save to database or config file
   };
 

--- a/src/pages/developer/TestingSandbox.tsx
+++ b/src/pages/developer/TestingSandbox.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -13,22 +14,22 @@ const TestingSandbox: React.FC = () => {
 
   const startSimulation = (role: 'manager' | 'sales_rep') => {
     setSimulationMode(role);
-    console.log(`Starting ${role} simulation mode`);
+    logger.info(`Starting ${role} simulation mode`);
   };
 
   const stopSimulation = () => {
     setSimulationMode('off');
-    console.log('Stopping simulation mode');
+    logger.info('Stopping simulation mode');
   };
 
   const loadTestData = () => {
     setTestDataLoaded(true);
-    console.log('Loading test data...');
+    logger.info('Loading test data...');
   };
 
   const clearTestData = () => {
     setTestDataLoaded(false);
-    console.log('Clearing test data...');
+    logger.info('Clearing test data...');
   };
 
   return (

--- a/src/pages/manager/ManagerDashboard.tsx
+++ b/src/pages/manager/ManagerDashboard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -149,7 +150,7 @@ const ManagerDashboard = () => {
           .single();
           
         if (statsError && statsError.code !== 'PGRST116') { // PGRST116 is "no rows returned" error
-          console.error('Error fetching stats for user', profile.id, statsError);
+          logger.error('Error fetching stats for user', profile.id, statsError);
           continue;
         }
         
@@ -176,7 +177,7 @@ const ManagerDashboard = () => {
       setRecommendations([]);
       
     } catch (error) {
-      console.error('Error fetching data:', error);
+      logger.error('Error fetching data:', error);
     } finally {
       setLoading(false);
     }

--- a/src/pages/manager/Settings.tsx
+++ b/src/pages/manager/Settings.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -52,7 +53,7 @@ const ManagerSettings = () => {
   });
 
   const handleSave = () => {
-    console.log('Saving settings:', settings);
+    logger.info('Saving settings:', settings);
     // In a real app, this would save to the backend
   };
 

--- a/src/pages/onboarding/OnboardingContext.tsx
+++ b/src/pages/onboarding/OnboardingContext.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
@@ -172,7 +173,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
       // Return the referral code
       return code;
     } catch (error: any) {
-      console.error('Error generating referral link:', error);
+      logger.error('Error generating referral link:', error);
       toast.error('Failed to generate referral link: ' + error.message);
       return null;
     }
@@ -195,7 +196,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
           event_data: { settings: enhancedSettings }
         });
     } catch (error) {
-      console.error('Failed to track onboarding completion:', error);
+      logger.error('Failed to track onboarding completion:', error);
     }
     
     // Call the provided completion function
@@ -259,7 +260,7 @@ export const buildDashboardFromSettings = async (options: BuildDashboardOptions)
       
     return true;
   } catch (error) {
-    console.error('Error building dashboard from settings:', error);
+    logger.error('Error building dashboard from settings:', error);
     
     // Track failed build
     await supabase

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -74,7 +75,7 @@ const OnboardingPage: React.FC = () => {
           navigate(redirectPath);
         }
       } catch (err) {
-        console.error('Error checking onboarding status:', err);
+        logger.error('Error checking onboarding status:', err);
       }
     };
     
@@ -125,7 +126,7 @@ const OnboardingPage: React.FC = () => {
       }, 3000);
       
     } catch (error: any) {
-      console.error('Error saving onboarding settings:', error);
+      logger.error('Error saving onboarding settings:', error);
       toast.error('Failed to save settings: ' + error.message);
       setIsSubmitting(false);
     }

--- a/src/pages/onboarding/steps/RevealStep.tsx
+++ b/src/pages/onboarding/steps/RevealStep.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -38,7 +39,7 @@ const RevealStep: React.FC<RevealStepProps> = ({ settings, completeOnboarding, i
         toast.success('Referral link generated successfully!');
       }
     } catch (error) {
-      console.error('Error generating referral:', error);
+      logger.error('Error generating referral:', error);
     } finally {
       setIsGeneratingReferral(false);
     }
@@ -68,7 +69,7 @@ const RevealStep: React.FC<RevealStepProps> = ({ settings, completeOnboarding, i
           url: referralUrl,
         });
       } catch (error) {
-        console.error('Error sharing:', error);
+        logger.error('Error sharing:', error);
         // Fallback to copying to clipboard
         copyReferralLink();
       }

--- a/src/pages/sales/Dashboard.tsx
+++ b/src/pages/sales/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -32,7 +33,7 @@ const SalesDashboard = () => {
           .single();
         setUserStats(data);
       } catch (error) {
-        console.log('No user stats found, using defaults');
+        logger.info('No user stats found, using defaults');
       }
     };
 
@@ -101,7 +102,7 @@ const SalesDashboard = () => {
   ];
 
   const handleActionClick = (actionId: string) => {
-    console.log('Action clicked:', actionId);
+    logger.info('Action clicked:', actionId);
   };
 
   return (

--- a/src/pages/sales/SalesRepDashboard.tsx
+++ b/src/pages/sales/SalesRepDashboard.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 import React, { useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useMockData } from '@/hooks/useMockData';
@@ -83,11 +84,11 @@ const SalesRepDashboard: React.FC = () => {
   ];
 
   const handleLeadClick = (leadId: string) => {
-    console.log('Lead clicked:', leadId);
+    logger.info('Lead clicked:', leadId);
   };
 
   const handleActionClick = (actionId: string) => {
-    console.log('Action clicked:', actionId);
+    logger.info('Action clicked:', actionId);
   };
 
   const getProgressPercentage = (current: number, target: number) => {

--- a/src/services/ai/aiLearningLayer.ts
+++ b/src/services/ai/aiLearningLayer.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { dataEncryptionService } from '../security/dataEncryptionService';
@@ -74,7 +75,7 @@ export class AILearningLayer {
         visibility: 'admin_only'
       });
     } catch (error) {
-      console.error('Failed to store learning data:', error);
+      logger.error('Failed to store learning data:', error);
     }
   }
 
@@ -91,7 +92,7 @@ export class AILearningLayer {
         await this.generateImprovements(companyId, companyData);
       }
     } catch (error) {
-      console.error('Error processing learning buffer:', error);
+      logger.error('Error processing learning buffer:', error);
     }
   }
 
@@ -148,7 +149,7 @@ export class AILearningLayer {
         });
       }
     } catch (error) {
-      console.error('Failed to generate improvements for company:', companyId, error);
+      logger.error('Failed to generate improvements for company:', companyId, error);
     }
   }
 
@@ -194,7 +195,7 @@ export class AILearningLayer {
         }
       }
     } catch (error) {
-      console.error('Error parsing improvement suggestions:', error);
+      logger.error('Error parsing improvement suggestions:', error);
     }
     
     return improvements;
@@ -272,7 +273,7 @@ export class AILearningLayer {
         .update({ accepted: true })
         .eq('id', improvementId);
     } catch (error) {
-      console.error('Failed to mark improvement as implemented:', error);
+      logger.error('Failed to mark improvement as implemented:', error);
     }
   }
 }

--- a/src/services/ai/automationEngine.ts
+++ b/src/services/ai/automationEngine.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { 
@@ -79,7 +80,7 @@ export class NativeAutomationEngine {
       };
 
     } catch (error) {
-      console.error('Error creating automation flow:', error);
+      logger.error('Error creating automation flow:', error);
       return {
         success: false,
         message: 'Failed to create automation flow'
@@ -128,7 +129,7 @@ export class NativeAutomationEngine {
       return result;
 
     } catch (error) {
-      console.error('Error executing flow:', error);
+      logger.error('Error executing flow:', error);
       return {
         success: false,
         message: 'Flow execution failed'
@@ -155,7 +156,7 @@ export class NativeAutomationEngine {
       return null;
 
     } catch (error) {
-      console.error('Error getting flow:', error);
+      logger.error('Error getting flow:', error);
       return null;
     }
   }

--- a/src/services/ai/automationFlowService.ts
+++ b/src/services/ai/automationFlowService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { SimpleAutomationFlow, FlowExecutionContext } from './types/automationFlowTypes';
@@ -30,7 +31,7 @@ export class AutomationFlowService {
         }
       }
     } catch (error) {
-      console.error('Error evaluating flow triggers:', error);
+      logger.error('Error evaluating flow triggers:', error);
     }
   }
 
@@ -107,7 +108,7 @@ export class AutomationFlowService {
           visibility: 'admin_only'
         });
     } catch (error) {
-      console.error('Error logging flow execution:', error);
+      logger.error('Error logging flow execution:', error);
     }
   }
 }

--- a/src/services/ai/claudeAIService.ts
+++ b/src/services/ai/claudeAIService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 
 import { supabase } from '@/integrations/supabase/client';
@@ -44,7 +45,7 @@ export class ClaudeAIService {
         usage: response.usage
       };
     } catch (error) {
-      console.error('Claude pattern analysis failed:', error);
+      logger.error('Claude pattern analysis failed:', error);
       throw new Error('Claude analysis service unavailable');
     }
   }
@@ -70,7 +71,7 @@ export class ClaudeAIService {
         usage: response.usage
       };
     } catch (error) {
-      console.error('Claude summarization failed:', error);
+      logger.error('Claude summarization failed:', error);
       throw new Error('Claude summarization service unavailable');
     }
   }
@@ -96,7 +97,7 @@ export class ClaudeAIService {
         usage: response.usage
       };
     } catch (error) {
-      console.error('Claude system insights failed:', error);
+      logger.error('Claude system insights failed:', error);
       throw new Error('Claude insights service unavailable');
     }
   }
@@ -122,7 +123,7 @@ export class ClaudeAIService {
         usage: response.usage
       };
     } catch (error) {
-      console.error('Claude market contextualization failed:', error);
+      logger.error('Claude market contextualization failed:', error);
       throw new Error('Claude market analysis service unavailable');
     }
   }

--- a/src/services/ai/elevenLabsService.ts
+++ b/src/services/ai/elevenLabsService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
@@ -14,14 +15,14 @@ class ElevenLabsService {
       this.serviceReady = !error;
 
       if (this.serviceReady) {
-        console.log('ElevenLabs service initialized successfully');
+        logger.info('ElevenLabs service initialized successfully');
       } else {
-        console.error('ElevenLabs service initialization failed');
+        logger.error('ElevenLabs service initialization failed');
       }
 
       return this.serviceReady;
     } catch (error) {
-      console.error('Failed to initialize ElevenLabs service:', error);
+      logger.error('Failed to initialize ElevenLabs service:', error);
       this.serviceReady = false;
       return false;
     }
@@ -44,7 +45,7 @@ class ElevenLabsService {
 
       return data.url as string;
     } catch (error) {
-      console.error('Error generating speech:', error);
+      logger.error('Error generating speech:', error);
       toast.error('Failed to generate voice response');
       return null;
     }

--- a/src/services/ai/email/emailSchedulingService.ts
+++ b/src/services/ai/email/emailSchedulingService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -35,7 +36,7 @@ export class EmailSchedulingService {
 
       return data.id;
     } catch (error) {
-      console.error('Error scheduling email:', error);
+      logger.error('Error scheduling email:', error);
       throw error;
     }
   }
@@ -84,7 +85,7 @@ export class EmailSchedulingService {
             .eq('id', emailLog.id);
 
         } catch (error) {
-          console.error('Error processing scheduled email:', error);
+          logger.error('Error processing scheduled email:', error);
           
           const payload = this.safeExtractEmailPayload(emailLog.payload);
           const failedPayload = {
@@ -100,7 +101,7 @@ export class EmailSchedulingService {
         }
       }
     } catch (error) {
-      console.error('Error processing scheduled emails:', error);
+      logger.error('Error processing scheduled emails:', error);
     }
   }
 

--- a/src/services/ai/email/emailTemplateService.ts
+++ b/src/services/ai/email/emailTemplateService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -39,7 +40,7 @@ export class EmailTemplateService {
         companyId: data.company_id
       };
     } catch (error) {
-      console.error('Error creating email template:', error);
+      logger.error('Error creating email template:', error);
       throw error;
     }
   }
@@ -70,7 +71,7 @@ export class EmailTemplateService {
 
       return { subject, body };
     } catch (error) {
-      console.error('Error generating email from template:', error);
+      logger.error('Error generating email from template:', error);
       throw error;
     }
   }

--- a/src/services/ai/emailAutomationService.ts
+++ b/src/services/ai/emailAutomationService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { automationFlowService } from './automationFlowService';
 import { emailTemplateService, EmailTemplate } from './email/emailTemplateService';
@@ -53,7 +54,7 @@ export class EmailAutomationService {
 
       await automationFlowService.evaluateFlowTriggers(trigger, flowContext);
     } catch (error) {
-      console.error('Error evaluating automation triggers:', error);
+      logger.error('Error evaluating automation triggers:', error);
     }
   }
 }

--- a/src/services/ai/enhancedVoiceService.ts
+++ b/src/services/ai/enhancedVoiceService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { voiceService } from './voiceService';
 import { hybridAIOrchestrator } from './hybridAIOrchestrator';
@@ -60,7 +61,7 @@ export class EnhancedVoiceService {
       
       return started;
     } catch (error) {
-      console.error('Failed to start voice listening:', error);
+      logger.error('Failed to start voice listening:', error);
       this.isListening = false;
       return false;
     }
@@ -86,7 +87,7 @@ export class EnhancedVoiceService {
       return command;
       
     } catch (error) {
-      console.error('Error processing voice command:', error);
+      logger.error('Error processing voice command:', error);
       return null;
     }
   }
@@ -200,14 +201,14 @@ export class EnhancedVoiceService {
       try {
         await voiceService.generateVoiceResponse(voiceResponse.text);
       } catch (error) {
-        console.error('Failed to generate voice response:', error);
+        logger.error('Failed to generate voice response:', error);
         // Continue without audio
       }
 
       return voiceResponse;
       
     } catch (error) {
-      console.error('Error processing voice command:', error);
+      logger.error('Error processing voice command:', error);
       
       return {
         text: "I'm sorry, I couldn't process that command. Could you please try again?",
@@ -223,7 +224,7 @@ export class EnhancedVoiceService {
     try {
       await voiceService.generateVoiceResponse(text);
     } catch (error) {
-      console.error('Failed to speak response:', error);
+      logger.error('Failed to speak response:', error);
     }
   }
 

--- a/src/services/ai/industryTemplates.ts
+++ b/src/services/ai/industryTemplates.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { AutomationFlow, EmailTemplate } from './types/automationTypes';
 
@@ -216,11 +217,11 @@ export class IndustryTemplateService {
       const automationFlows = INDUSTRY_AUTOMATION_FLOWS[industry] || [];
       for (const flow of automationFlows) {
         // Create flow logic would go here
-        console.log(`Setting up flow: ${flow.name} for industry: ${industry}`);
+        logger.info(`Setting up flow: ${flow.name} for industry: ${industry}`);
       }
 
     } catch (error) {
-      console.error('Error setting up industry templates:', error);
+      logger.error('Error setting up industry templates:', error);
     }
   }
 

--- a/src/services/ai/insightGenerator.ts
+++ b/src/services/ai/insightGenerator.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { AIIngestionEvent, AIInsight } from './types';
@@ -65,7 +66,7 @@ export class InsightGenerator {
 
       return data || [];
     } catch (error) {
-      console.error('Error fetching call history:', error);
+      logger.error('Error fetching call history:', error);
       return [];
     }
   }
@@ -91,7 +92,7 @@ export class InsightGenerator {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error storing insight:', error);
+      logger.error('Error storing insight:', error);
     }
   }
 }

--- a/src/services/ai/learningEngine.ts
+++ b/src/services/ai/learningEngine.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { AIIngestionEvent } from './types';
@@ -22,7 +23,7 @@ export class LearningEngine {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Error updating learning models:', error);
+      logger.error('Error updating learning models:', error);
     }
   }
 }

--- a/src/services/ai/recommendationService.ts
+++ b/src/services/ai/recommendationService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { AIRecommendation } from './types';
@@ -41,7 +42,7 @@ export class RecommendationService {
 
       return recommendations;
     } catch (error) {
-      console.error('Error getting personalized recommendations:', error);
+      logger.error('Error getting personalized recommendations:', error);
       return [];
     }
   }

--- a/src/services/ai/voiceService.ts
+++ b/src/services/ai/voiceService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { toast } from 'sonner';
 
@@ -22,7 +23,7 @@ class VoiceService {
       stream.getTracks().forEach(track => track.stop());
       return true;
     } catch (error) {
-      console.error('Microphone permission denied:', error);
+      logger.error('Microphone permission denied:', error);
       toast.error('Microphone access denied. Please allow microphone access.');
       return false;
     }
@@ -50,7 +51,7 @@ class VoiceService {
       this.mediaRecorderRef.start();
       return true;
     } catch (error) {
-      console.error('Failed to start recording:', error);
+      logger.error('Failed to start recording:', error);
       toast.error('Failed to start voice recording');
       return false;
     }
@@ -79,7 +80,7 @@ class VoiceService {
       const base64Audio = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
 
       // Mock transcription for now - in production this would call Whisper API
-      console.log('Processing audio command...');
+      logger.info('Processing audio command...');
       
       // Simulate processing delay
       await new Promise(resolve => setTimeout(resolve, 1000));
@@ -87,7 +88,7 @@ class VoiceService {
       // Return mock transcription
       return "Generate a follow-up email for this lead";
     } catch (error) {
-      console.error('Error processing audio command:', error);
+      logger.error('Error processing audio command:', error);
       throw new Error('Failed to process voice command');
     }
   }
@@ -108,7 +109,7 @@ class VoiceService {
         });
       }
     } catch (error) {
-      console.error('Error generating voice response:', error);
+      logger.error('Error generating voice response:', error);
     }
   }
 

--- a/src/services/audit/auditExportService.ts
+++ b/src/services/audit/auditExportService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { accessControlService } from '@/services/security/accessControlService';
 import { AuditEntry } from '@/hooks/audit/types';
@@ -61,7 +62,7 @@ export class AuditExportService {
       );
 
     } catch (error) {
-      console.error('Failed to export audit trail:', error);
+      logger.error('Failed to export audit trail:', error);
       throw error;
     }
   }

--- a/src/services/audit/auditLoggingService.ts
+++ b/src/services/audit/auditLoggingService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { encryptionService } from '@/services/security/encryptionService';
@@ -58,7 +59,7 @@ export class AuditLoggingService {
       }
 
     } catch (error) {
-      console.error('Failed to log audit event:', error);
+      logger.error('Failed to log audit event:', error);
       accessControlService.logSecurityEvent(
         'Audit logging failure',
         { action, resource, error: error instanceof Error ? error.message : 'Unknown error' },

--- a/src/services/audit/auditRetrievalService.ts
+++ b/src/services/audit/auditRetrievalService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { encryptionService } from '@/services/security/encryptionService';
@@ -10,7 +11,7 @@ export class AuditRetrievalService {
     filters?: AuditFilters
   ): Promise<AuditEntry[]> {
     if (!accessControlService.checkAccess('ai_audit_trail', 'read', userRole)) {
-      console.warn('Insufficient permissions to access audit trail');
+      logger.warn('Insufficient permissions to access audit trail');
       return [];
     }
 
@@ -56,7 +57,7 @@ export class AuditRetrievalService {
               userAgent: payload.auditEntry.userAgent
             } as AuditEntry;
           } catch (decryptError) {
-            console.error('Failed to decrypt audit entry:', decryptError);
+            logger.error('Failed to decrypt audit entry:', decryptError);
             return null;
           }
         })
@@ -65,7 +66,7 @@ export class AuditRetrievalService {
       return decryptedEntries.filter(Boolean) as AuditEntry[];
 
     } catch (error) {
-      console.error('Failed to fetch audit trail:', error);
+      logger.error('Failed to fetch audit trail:', error);
       accessControlService.logSecurityEvent(
         'Audit trail access failure',
         { error: error instanceof Error ? error.message : 'Unknown error' },

--- a/src/services/automation/workflowService.ts
+++ b/src/services/automation/workflowService.ts
@@ -173,7 +173,7 @@ export class WorkflowService {
   private async sendEmail(parameters: any, triggerData?: any): Promise<boolean> {
     try {
       // Simulate email sending for now
-      console.log('Sending email:', { parameters, triggerData });
+      logger.info('Sending email:', { parameters, triggerData });
       return true;
     } catch (error) {
       logger.error('Email sending failed', error, 'automation');
@@ -184,7 +184,7 @@ export class WorkflowService {
   private async makeCall(parameters: any, triggerData?: any): Promise<boolean> {
     try {
       // Simulate call making for now
-      console.log('Making call:', { parameters, triggerData });
+      logger.info('Making call:', { parameters, triggerData });
       return true;
     } catch (error) {
       logger.error('Call initiation failed', error, 'automation');
@@ -209,7 +209,7 @@ export class WorkflowService {
   private async createTask(parameters: any, triggerData?: any): Promise<boolean> {
     try {
       // For now, simulate task creation since tasks table may not exist
-      console.log('Creating task:', { parameters, triggerData });
+      logger.info('Creating task:', { parameters, triggerData });
       return true;
     } catch (error) {
       logger.error('Task creation failed', error, 'automation');
@@ -220,7 +220,7 @@ export class WorkflowService {
   private async sendSMS(parameters: any, triggerData?: any): Promise<boolean> {
     try {
       // Simulate SMS sending for now
-      console.log('Sending SMS:', { parameters, triggerData });
+      logger.info('Sending SMS:', { parameters, triggerData });
       return true;
     } catch (error) {
       logger.error('SMS sending failed', error, 'automation');
@@ -236,7 +236,7 @@ export class WorkflowService {
       const response = await unifiedAIService.generateResponse(prompt, undefined, context);
       
       // Log the analysis result instead of storing in non-existent table
-      console.log('AI Analysis completed:', response);
+      logger.info('AI Analysis completed:', response);
 
       return true;
     } catch (error) {

--- a/src/services/companyBrain/aiInsightsService.ts
+++ b/src/services/companyBrain/aiInsightsService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { AIInsight, DataIngestionStatus } from './types';
@@ -69,7 +70,7 @@ export class AIInsightsService {
 
       return insights;
     } catch (error) {
-      console.error('Error generating insights:', error);
+      logger.error('Error generating insights:', error);
       return [];
     }
   }
@@ -105,7 +106,7 @@ export class AIInsightsService {
         errors: []
       };
     } catch (error) {
-      console.error('Error getting data ingestion status:', error);
+      logger.error('Error getting data ingestion status:', error);
       return {
         social: { connected: 0, total: 4 },
         website: { status: 'disconnected' },
@@ -155,7 +156,7 @@ Data Source: ${insight.type}
 
       return brief;
     } catch (error) {
-      console.error('Error creating campaign brief:', error);
+      logger.error('Error creating campaign brief:', error);
       throw error;
     }
   }

--- a/src/services/companyBrain/documentService.ts
+++ b/src/services/companyBrain/documentService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { UploadedFile } from './types';
@@ -41,7 +42,7 @@ export class DocumentService {
         uploadedFiles.push(uploadedFile);
         toast.success(`${file.name} uploaded successfully`);
       } catch (error) {
-        console.error('Error uploading file:', error);
+        logger.error('Error uploading file:', error);
         toast.error(`Failed to upload ${file.name}`);
       }
     }
@@ -75,7 +76,7 @@ export class DocumentService {
         };
       });
     } catch (error) {
-      console.error('Error getting uploaded files:', error);
+      logger.error('Error getting uploaded files:', error);
       return [];
     }
   }
@@ -96,7 +97,7 @@ export class DocumentService {
           visibility: 'admin_only'
         });
     } catch (error) {
-      console.error('Error categorizing file:', error);
+      logger.error('Error categorizing file:', error);
     }
   }
 

--- a/src/services/companyBrain/socialMediaService.ts
+++ b/src/services/companyBrain/socialMediaService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { SocialMediaConnection } from './types';
@@ -25,7 +26,7 @@ export class SocialMediaService {
       toast.info(`${platform} OAuth integration coming soon`);
       return false;
     } catch (error) {
-      console.error('Error connecting platform:', error);
+      logger.error('Error connecting platform:', error);
       return false;
     }
   }
@@ -51,7 +52,7 @@ export class SocialMediaService {
         metrics: undefined
       }));
     } catch (error) {
-      console.error('Error getting social connections:', error);
+      logger.error('Error getting social connections:', error);
       return [];
     }
   }
@@ -81,7 +82,7 @@ export class SocialMediaService {
         lastSync: new Date()
       };
     } catch (error) {
-      console.error('Error syncing platform data:', error);
+      logger.error('Error syncing platform data:', error);
       throw error;
     }
   }

--- a/src/services/companyBrain/websiteService.ts
+++ b/src/services/companyBrain/websiteService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { WebsiteData } from './types';
@@ -45,7 +46,7 @@ export class WebsiteService {
         }
       };
     } catch (error) {
-      console.error('Error crawling website:', error);
+      logger.error('Error crawling website:', error);
       throw error;
     }
   }
@@ -77,7 +78,7 @@ export class WebsiteService {
         }
       };
     } catch (error) {
-      console.error('Error getting website data:', error);
+      logger.error('Error getting website data:', error);
       return null;
     }
   }

--- a/src/services/integrations/clickupCRM/api.ts
+++ b/src/services/integrations/clickupCRM/api.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { clickUpAuth } from './auth';
 import { ClickUpErrorHandler } from './errorHandler';
@@ -234,7 +235,7 @@ export class ClickUpAPI {
     const retryAfter = response.headers.get('Retry-After');
     const delayMs = retryAfter ? parseInt(retryAfter) * 1000 : 60000;
     
-    console.warn(`ClickUp API rate limit hit. Retrying after ${delayMs}ms`);
+    logger.warn(`ClickUp API rate limit hit. Retrying after ${delayMs}ms`);
     await new Promise(resolve => setTimeout(resolve, delayMs));
   }
 
@@ -243,7 +244,7 @@ export class ClickUpAPI {
       await this.getCurrentUser();
       return true;
     } catch (error) {
-      console.error('ClickUp connection test failed:', error);
+      logger.error('ClickUp connection test failed:', error);
       return false;
     }
   }

--- a/src/services/integrations/clickupCRM/auth.ts
+++ b/src/services/integrations/clickupCRM/auth.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -39,7 +40,7 @@ export class ClickUpAuth {
       this.authConfig.clientId = 'placeholder_client_id';
       this.authConfig.clientSecret = 'placeholder_client_secret';
     } catch (error) {
-      console.warn('Failed to load ClickUp configuration:', error);
+      logger.warn('Failed to load ClickUp configuration:', error);
     }
   }
 
@@ -88,7 +89,7 @@ export class ClickUpAuth {
       await this.storeTokens(tokens);
       return tokens;
     } catch (error) {
-      console.error('ClickUp token exchange failed:', error);
+      logger.error('ClickUp token exchange failed:', error);
       throw error;
     }
   }
@@ -114,7 +115,7 @@ export class ClickUpAuth {
       await this.storeTokens(tokens);
       return tokens;
     } catch (error) {
-      console.error('ClickUp token validation failed:', error);
+      logger.error('ClickUp token validation failed:', error);
       throw error;
     }
   }
@@ -144,7 +145,7 @@ export class ClickUpAuth {
 
       return tokens.accessToken;
     } catch (error) {
-      console.error('Failed to get valid access token:', error);
+      logger.error('Failed to get valid access token:', error);
       throw error;
     }
   }
@@ -186,7 +187,7 @@ export class ClickUpAuth {
       await this.storeTokens(tokens);
       return tokens;
     } catch (error) {
-      console.error('ClickUp token refresh failed:', error);
+      logger.error('ClickUp token refresh failed:', error);
       throw error;
     }
   }
@@ -210,7 +211,7 @@ export class ClickUpAuth {
 
       if (error) throw error;
     } catch (error) {
-      console.error('Failed to store ClickUp tokens:', error);
+      logger.error('Failed to store ClickUp tokens:', error);
       throw error;
     }
   }
@@ -237,7 +238,7 @@ export class ClickUpAuth {
         expiresAt: data.expires_at ? new Date(data.expires_at).getTime() : undefined
       };
     } catch (error) {
-      console.error('Failed to get stored tokens:', error);
+      logger.error('Failed to get stored tokens:', error);
       return null;
     }
   }
@@ -263,7 +264,7 @@ export class ClickUpAuth {
         .eq('user_id', user.id)
         .eq('provider', 'clickup');
     } catch (error) {
-      console.error('Failed to disconnect ClickUp:', error);
+      logger.error('Failed to disconnect ClickUp:', error);
       throw error;
     }
   }

--- a/src/services/integrations/clickupCRM/errorHandler.ts
+++ b/src/services/integrations/clickupCRM/errorHandler.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -72,7 +73,7 @@ export class ClickUpErrorHandler {
         .from('error_logs')
         .insert(errorLog);
 
-      console.error('ClickUp Error:', {
+      logger.error('ClickUp Error:', {
         context,
         error: error.message || error,
         details: error.details,
@@ -80,8 +81,8 @@ export class ClickUpErrorHandler {
       });
 
     } catch (logError) {
-      console.error('Failed to log ClickUp error to database:', logError);
-      console.error('Original ClickUp error:', error);
+      logger.error('Failed to log ClickUp error to database:', logError);
+      logger.error('Original ClickUp error:', error);
     }
   }
 
@@ -169,7 +170,7 @@ export class ClickUpErrorHandler {
 
   private async notifyUser(message: string): Promise<void> {
     try {
-      console.warn('User Notification:', message);
+      logger.warn('User Notification:', message);
       
       const userId = await this.getCurrentUserId();
       if (userId) {
@@ -186,7 +187,7 @@ export class ClickUpErrorHandler {
           });
       }
     } catch (error) {
-      console.error('Failed to notify user:', error);
+      logger.error('Failed to notify user:', error);
     }
   }
 

--- a/src/services/integrations/clickupCRM/helpers.ts
+++ b/src/services/integrations/clickupCRM/helpers.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { DatabaseLead } from '@/hooks/useLeads';
 
@@ -64,7 +65,7 @@ export class ClickUpHelpers {
         is_sensitive: this.checkIfSensitiveTask(task)
       };
     } catch (error) {
-      console.error('Error transforming ClickUp task:', error);
+      logger.error('Error transforming ClickUp task:', error);
       throw new Error(`Failed to transform ClickUp task ${task.id}: ${error.message}`);
     }
   }
@@ -296,7 +297,7 @@ export class ClickUpHelpers {
       
       return Math.floor(diffMinutes / 60);
     } catch (error) {
-      console.error('Error calculating speed to lead:', error);
+      logger.error('Error calculating speed to lead:', error);
       return 0;
     }
   }
@@ -326,7 +327,7 @@ export class ClickUpHelpers {
     try {
       return new Date(dateString);
     } catch (error) {
-      console.error('Invalid date format from ClickUp:', dateString);
+      logger.error('Invalid date format from ClickUp:', dateString);
       return null;
     }
   }

--- a/src/services/integrations/clickupCRM/webhooks.ts
+++ b/src/services/integrations/clickupCRM/webhooks.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { masterAIBrain } from '@/services/masterAIBrain';
@@ -41,7 +42,7 @@ export class ClickUpWebhooks {
 
   async handleWebhook(payload: ClickUpWebhookPayload): Promise<void> {
     try {
-      console.log('Processing ClickUp webhook:', payload);
+      logger.info('Processing ClickUp webhook:', payload);
 
       switch (payload.event) {
         case 'taskCreated':
@@ -57,7 +58,7 @@ export class ClickUpWebhooks {
           await this.handleTaskStatusUpdated(payload.task_id, payload.history_items);
           break;
         default:
-          console.log(`Unhandled ClickUp event: ${payload.event}`);
+          logger.info(`Unhandled ClickUp event: ${payload.event}`);
       }
     } catch (error) {
       await this.errorHandler.logError(error, 'Webhook processing failed');
@@ -68,7 +69,7 @@ export class ClickUpWebhooks {
     try {
       if (!taskId) return;
       
-      console.log(`Handling ClickUp task creation: ${taskId}`);
+      logger.info(`Handling ClickUp task creation: ${taskId}`);
       await this.syncTaskFromClickUp(taskId, 'created');
     } catch (error) {
       await this.errorHandler.logError(error, 'Failed to handle task creation webhook');
@@ -79,13 +80,13 @@ export class ClickUpWebhooks {
     try {
       if (!taskId) return;
       
-      console.log(`Handling ClickUp task update: ${taskId}`);
+      logger.info(`Handling ClickUp task update: ${taskId}`);
       await this.syncTaskFromClickUp(taskId, 'updated');
       
       // Log specific field changes
       if (historyItems) {
         for (const item of historyItems) {
-          console.log(`Field ${item.field} changed:`, item.data);
+          logger.info(`Field ${item.field} changed:`, item.data);
         }
       }
     } catch (error) {
@@ -97,7 +98,7 @@ export class ClickUpWebhooks {
     try {
       if (!taskId) return;
       
-      console.log(`Handling ClickUp task deletion: ${taskId}`);
+      logger.info(`Handling ClickUp task deletion: ${taskId}`);
       await this.markTaskAsDeleted(taskId);
     } catch (error) {
       await this.errorHandler.logError(error, 'Failed to handle task deletion webhook');
@@ -108,12 +109,12 @@ export class ClickUpWebhooks {
     try {
       if (!taskId) return;
       
-      console.log(`Handling ClickUp task status update: ${taskId}`);
+      logger.info(`Handling ClickUp task status update: ${taskId}`);
       
       // Find status change in history
       const statusChange = historyItems?.find(item => item.field === 'status');
       if (statusChange) {
-        console.log(`Status changed to: ${statusChange.data?.status?.status}`);
+        logger.info(`Status changed to: ${statusChange.data?.status?.status}`);
       }
       
       await this.syncTaskFromClickUp(taskId, 'status_updated');
@@ -124,7 +125,7 @@ export class ClickUpWebhooks {
 
   private async syncTaskFromClickUp(taskId: string, operation: string): Promise<void> {
     try {
-      console.log(`Syncing ClickUp task ${taskId} (${operation})`);
+      logger.info(`Syncing ClickUp task ${taskId} (${operation})`);
 
       const task = await clickUpAPI.getTask(taskId);
       if (!task) {
@@ -236,13 +237,13 @@ export class ClickUpWebhooks {
           created_at: new Date().toISOString()
         });
     } catch (logError) {
-      console.error('Failed to log webhook activity:', logError);
+      logger.error('Failed to log webhook activity:', logError);
     }
   }
 
   async setupWebhooks(listIds: string[]): Promise<boolean> {
     try {
-      console.log('Setting up ClickUp webhooks for lists:', listIds);
+      logger.info('Setting up ClickUp webhooks for lists:', listIds);
       
       // TODO: Implement webhook setup via ClickUp API
       // This would create webhooks for each list to monitor task changes
@@ -266,7 +267,7 @@ export class ClickUpWebhooks {
 
       return computed === signature;
     } catch (error) {
-      console.error('Webhook signature validation failed:', error);
+      logger.error('Webhook signature validation failed:', error);
       return false;
     }
   }

--- a/src/services/integrations/crmDataMapper.ts
+++ b/src/services/integrations/crmDataMapper.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { toast } from 'sonner';
 
@@ -73,7 +74,7 @@ export class CRMDataMapper {
         const sourceValue = this.getNestedValue(zohoLead, template.sourceField);
         
         if (template.required && !sourceValue) {
-          console.warn(`Missing required field: ${template.sourceField} for Zoho lead ${zohoLead.id}`);
+          logger.warn(`Missing required field: ${template.sourceField} for Zoho lead ${zohoLead.id}`);
           continue;
         }
 
@@ -106,7 +107,7 @@ export class CRMDataMapper {
         conversion_likelihood: this.calculateConversionLikelihood(mappedData)
       } as CRMLeadData;
     } catch (error) {
-      console.error('Error mapping Zoho lead:', error);
+      logger.error('Error mapping Zoho lead:', error);
       throw new Error(`Failed to map Zoho lead ${zohoLead.id}: ${error.message}`);
     }
   }
@@ -125,7 +126,7 @@ export class CRMDataMapper {
         const sourceValue = this.getNestedValue(clickUpTask, template.sourceField);
         
         if (template.required && !sourceValue) {
-          console.warn(`Missing required field: ${template.sourceField} for ClickUp task ${clickUpTask.id}`);
+          logger.warn(`Missing required field: ${template.sourceField} for ClickUp task ${clickUpTask.id}`);
           continue;
         }
 
@@ -168,7 +169,7 @@ export class CRMDataMapper {
         conversion_likelihood: this.calculateConversionLikelihood(mappedData)
       } as CRMLeadData;
     } catch (error) {
-      console.error('Error mapping ClickUp task:', error);
+      logger.error('Error mapping ClickUp task:', error);
       throw new Error(`Failed to map ClickUp task ${clickUpTask.id}: ${error.message}`);
     }
   }

--- a/src/services/integrations/crmOrchestrator.ts
+++ b/src/services/integrations/crmOrchestrator.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { toast } from 'sonner';
 import { zohoCRMIntegration } from './zohoCRM';
@@ -46,7 +47,7 @@ export class CRMOrchestrator {
   }
 
   async initializeAllIntegrations(companyId: string): Promise<void> {
-    console.log('🚀 Initializing CRM integrations for company:', companyId);
+    logger.info('🚀 Initializing CRM integrations for company:', companyId);
 
     for (const provider of this.providers) {
       try {
@@ -54,15 +55,15 @@ export class CRMOrchestrator {
         provider.isActive = status.connected;
         
         if (provider.isActive) {
-          console.log(`✅ ${provider.name} is connected and active`);
+          logger.info(`✅ ${provider.name} is connected and active`);
           
           // Start auto-sync for connected providers
           this.startAutoSync(provider.id, companyId);
         } else {
-          console.log(`⚠️ ${provider.name} is not connected`);
+          logger.info(`⚠️ ${provider.name} is not connected`);
         }
       } catch (error) {
-        console.error(`❌ Error checking ${provider.name} status:`, error);
+        logger.error(`❌ Error checking ${provider.name} status:`, error);
         provider.isActive = false;
       }
     }
@@ -70,7 +71,7 @@ export class CRMOrchestrator {
     // Enable real-time sync
     await realTimeLeadSync.enableRealTimeSync(companyId);
     
-    console.log('🎯 CRM orchestrator initialization complete');
+    logger.info('🎯 CRM orchestrator initialization complete');
   }
 
   async connectProvider(providerId: string): Promise<{ success: boolean; authUrl?: string; error?: string }> {
@@ -89,7 +90,7 @@ export class CRMOrchestrator {
       
       return result;
     } catch (error) {
-      console.error(`Error connecting ${provider.name}:`, error);
+      logger.error(`Error connecting ${provider.name}:`, error);
       return { success: false, error: error.message };
     }
   }
@@ -111,7 +112,7 @@ export class CRMOrchestrator {
       
       return result;
     } catch (error) {
-      console.error(`Error disconnecting ${provider.name}:`, error);
+      logger.error(`Error disconnecting ${provider.name}:`, error);
       return { success: false, error: error.message };
     }
   }
@@ -123,7 +124,7 @@ export class CRMOrchestrator {
     }
 
     try {
-      console.log(`🔄 Starting sync for ${provider.name}...`);
+      logger.info(`🔄 Starting sync for ${provider.name}...`);
       
       let syncResult;
       if (providerId === 'zoho') {
@@ -134,10 +135,10 @@ export class CRMOrchestrator {
         throw new Error(`Sync not implemented for ${providerId}`);
       }
 
-      console.log(`✅ ${provider.name} sync completed:`, syncResult);
+      logger.info(`✅ ${provider.name} sync completed:`, syncResult);
       return syncResult;
     } catch (error) {
-      console.error(`❌ Error syncing ${provider.name}:`, error);
+      logger.error(`❌ Error syncing ${provider.name}:`, error);
       throw error;
     }
   }
@@ -146,11 +147,11 @@ export class CRMOrchestrator {
     const results = [];
     let overallSuccess = true;
 
-    console.log('🔄 Starting sync for all active providers...');
+    logger.info('🔄 Starting sync for all active providers...');
 
     for (const provider of this.providers) {
       if (!provider.isActive) {
-        console.log(`⏭️ Skipping ${provider.name} - not active`);
+        logger.info(`⏭️ Skipping ${provider.name} - not active`);
         continue;
       }
 
@@ -162,7 +163,7 @@ export class CRMOrchestrator {
           result
         });
       } catch (error) {
-        console.error(`❌ Failed to sync ${provider.name}:`, error);
+        logger.error(`❌ Failed to sync ${provider.name}:`, error);
         results.push({
           provider: provider.name,
           success: false,
@@ -172,7 +173,7 @@ export class CRMOrchestrator {
       }
     }
 
-    console.log('🎯 All provider sync completed. Overall success:', overallSuccess);
+    logger.info('🎯 All provider sync completed. Overall success:', overallSuccess);
     return { success: overallSuccess, results };
   }
 
@@ -182,15 +183,15 @@ export class CRMOrchestrator {
 
     const interval = setInterval(async () => {
       try {
-        console.log(`⏰ Auto-sync triggered for ${providerId}`);
+        logger.info(`⏰ Auto-sync triggered for ${providerId}`);
         await this.syncProvider(providerId, companyId, false);
       } catch (error) {
-        console.error(`❌ Auto-sync failed for ${providerId}:`, error);
+        logger.error(`❌ Auto-sync failed for ${providerId}:`, error);
       }
     }, intervalMinutes * 60 * 1000);
 
     this.syncIntervals.set(providerId, interval);
-    console.log(`⚡ Auto-sync started for ${providerId} (${intervalMinutes}min intervals)`);
+    logger.info(`⚡ Auto-sync started for ${providerId} (${intervalMinutes}min intervals)`);
   }
 
   private stopAutoSync(providerId: string): void {
@@ -198,7 +199,7 @@ export class CRMOrchestrator {
     if (interval) {
       clearInterval(interval);
       this.syncIntervals.delete(providerId);
-      console.log(`⏹️ Auto-sync stopped for ${providerId}`);
+      logger.info(`⏹️ Auto-sync stopped for ${providerId}`);
     }
   }
 
@@ -217,7 +218,7 @@ export class CRMOrchestrator {
       try {
         results[provider.id] = await provider.service.testConnection();
       } catch (error) {
-        console.error(`Connection test failed for ${provider.name}:`, error);
+        logger.error(`Connection test failed for ${provider.name}:`, error);
         results[provider.id] = false;
       }
     }
@@ -234,7 +235,7 @@ export class CRMOrchestrator {
     mappingConfig: any;
   }): Promise<void> {
     // This method would allow adding future CRMs dynamically
-    console.log('🔮 Custom CRM integration coming soon:', config.name);
+    logger.info('🔮 Custom CRM integration coming soon:', config.name);
     toast.info(`${config.name} integration will be available soon`);
   }
 }

--- a/src/services/integrations/realTimeLeadSync.ts
+++ b/src/services/integrations/realTimeLeadSync.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
@@ -40,14 +41,14 @@ export class RealTimeLeadSync {
     let duplicateCount = 0;
 
     try {
-      console.log(`Starting sync of ${leads.length} leads for company ${companyId}`);
+      logger.info(`Starting sync of ${leads.length} leads for company ${companyId}`);
 
       for (const leadData of leads) {
         try {
           // Validate lead data
           const validation = this.mapper.validateMappedLead(leadData);
           if (!validation.isValid) {
-            console.warn(`Invalid lead data for ${leadData.sourceId}:`, validation.errors);
+            logger.warn(`Invalid lead data for ${leadData.sourceId}:`, validation.errors);
             errorCount++;
             continue;
           }
@@ -80,7 +81,7 @@ export class RealTimeLeadSync {
           }
 
         } catch (leadError) {
-          console.error(`Error processing lead ${leadData.sourceId}:`, leadError);
+          logger.error(`Error processing lead ${leadData.sourceId}:`, leadError);
           errorCount++;
         }
       }
@@ -88,7 +89,7 @@ export class RealTimeLeadSync {
       // Log sync summary
       await this.logSyncSummary(companyId, syncedCount, errorCount, duplicateCount);
 
-      console.log(`Sync completed: ${syncedCount} new, ${duplicateCount} updated, ${errorCount} errors`);
+      logger.info(`Sync completed: ${syncedCount} new, ${duplicateCount} updated, ${errorCount} errors`);
 
       return {
         success: true,
@@ -99,7 +100,7 @@ export class RealTimeLeadSync {
       };
 
     } catch (error) {
-      console.error('Lead sync failed:', error);
+      logger.error('Lead sync failed:', error);
       return {
         success: false,
         synced: syncedCount,
@@ -152,12 +153,12 @@ export class RealTimeLeadSync {
       const { data, error } = await query.single();
       
       if (error && error.code !== 'PGRST116') { // PGRST116 = no rows returned
-        console.error('Error finding existing lead:', error);
+        logger.error('Error finding existing lead:', error);
       }
 
       return data;
     } catch (error) {
-      console.error('Error in findExistingLead:', error);
+      logger.error('Error in findExistingLead:', error);
       return null;
     }
   }
@@ -183,13 +184,13 @@ export class RealTimeLeadSync {
         });
 
       if (error) {
-        console.error('Error creating lead:', error);
+        logger.error('Error creating lead:', error);
         return false;
       }
 
       return true;
     } catch (error) {
-      console.error('Error in createNewLead:', error);
+      logger.error('Error in createNewLead:', error);
       return false;
     }
   }
@@ -213,13 +214,13 @@ export class RealTimeLeadSync {
         .eq('id', leadId);
 
       if (error) {
-        console.error('Error updating lead:', error);
+        logger.error('Error updating lead:', error);
         return false;
       }
 
       return true;
     } catch (error) {
-      console.error('Error in updateExistingLead:', error);
+      logger.error('Error in updateExistingLead:', error);
       return false;
     }
   }
@@ -237,7 +238,7 @@ export class RealTimeLeadSync {
         });
       }
     } catch (error) {
-      console.error('Error logging AI feedback:', error);
+      logger.error('Error logging AI feedback:', error);
     }
   }
 
@@ -257,7 +258,7 @@ export class RealTimeLeadSync {
         visibility: 'manager'
       });
     } catch (error) {
-      console.error('Error logging sync summary:', error);
+      logger.error('Error logging sync summary:', error);
     }
   }
 
@@ -275,7 +276,7 @@ export class RealTimeLeadSync {
             filter: `company_id=eq.${companyId}`
           },
           (payload) => {
-            console.log('Real-time lead change detected:', payload);
+            logger.info('Real-time lead change detected:', payload);
             
             // Show toast notification for lead changes
             if (payload.eventType === 'INSERT') {
@@ -287,9 +288,9 @@ export class RealTimeLeadSync {
         )
         .subscribe();
 
-      console.log('Real-time sync enabled for company:', companyId);
+      logger.info('Real-time sync enabled for company:', companyId);
     } catch (error) {
-      console.error('Error enabling real-time sync:', error);
+      logger.error('Error enabling real-time sync:', error);
     }
   }
 }

--- a/src/services/integrations/zohoCRM/api.ts
+++ b/src/services/integrations/zohoCRM/api.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { zohoAuth } from './auth';
 import { ZohoErrorHandler } from './errorHandler';
@@ -154,7 +155,7 @@ export class ZohoAPI {
     const retryAfter = response.headers.get('Retry-After');
     const delayMs = retryAfter ? parseInt(retryAfter) * 1000 : 60000; // Default 1 minute
     
-    console.warn(`Zoho API rate limit hit. Retrying after ${delayMs}ms`);
+    logger.warn(`Zoho API rate limit hit. Retrying after ${delayMs}ms`);
     await new Promise(resolve => setTimeout(resolve, delayMs));
   }
 
@@ -163,7 +164,7 @@ export class ZohoAPI {
       await this.makeRequest('/org');
       return true;
     } catch (error) {
-      console.error('Zoho connection test failed:', error);
+      logger.error('Zoho connection test failed:', error);
       return false;
     }
   }

--- a/src/services/integrations/zohoCRM/auth.ts
+++ b/src/services/integrations/zohoCRM/auth.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -41,7 +42,7 @@ export class ZohoAuth {
       this.authConfig.clientId = 'placeholder_client_id';
       this.authConfig.clientSecret = 'placeholder_client_secret';
     } catch (error) {
-      console.warn('Failed to load Zoho configuration:', error);
+      logger.warn('Failed to load Zoho configuration:', error);
     }
   }
 
@@ -94,7 +95,7 @@ export class ZohoAuth {
       await this.storeTokens(tokens);
       return tokens;
     } catch (error) {
-      console.error('Zoho token exchange failed:', error);
+      logger.error('Zoho token exchange failed:', error);
       throw error;
     }
   }
@@ -136,7 +137,7 @@ export class ZohoAuth {
       await this.storeTokens(tokens);
       return tokens;
     } catch (error) {
-      console.error('Zoho token refresh failed:', error);
+      logger.error('Zoho token refresh failed:', error);
       throw error;
     }
   }
@@ -159,7 +160,7 @@ export class ZohoAuth {
 
       return tokens.accessToken;
     } catch (error) {
-      console.error('Failed to get valid access token:', error);
+      logger.error('Failed to get valid access token:', error);
       throw error;
     }
   }
@@ -181,7 +182,7 @@ export class ZohoAuth {
           is_active: true
         });
     } catch (error) {
-      console.error('Failed to store Zoho tokens:', error);
+      logger.error('Failed to store Zoho tokens:', error);
       throw error;
     }
   }
@@ -208,7 +209,7 @@ export class ZohoAuth {
         expiresAt: new Date(data.expires_at).getTime()
       };
     } catch (error) {
-      console.error('Failed to get stored tokens:', error);
+      logger.error('Failed to get stored tokens:', error);
       return null;
     }
   }
@@ -234,7 +235,7 @@ export class ZohoAuth {
         .eq('user_id', user.id)
         .eq('provider', 'zoho');
     } catch (error) {
-      console.error('Failed to disconnect Zoho:', error);
+      logger.error('Failed to disconnect Zoho:', error);
       throw error;
     }
   }

--- a/src/services/integrations/zohoCRM/errorHandler.ts
+++ b/src/services/integrations/zohoCRM/errorHandler.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 
@@ -75,7 +76,7 @@ export class ZohoErrorHandler {
         .insert(errorLog);
 
       // Also log to console for immediate debugging
-      console.error('Zoho Error:', {
+      logger.error('Zoho Error:', {
         context,
         error: error.message || error,
         details: error.details,
@@ -84,8 +85,8 @@ export class ZohoErrorHandler {
 
     } catch (logError) {
       // Fallback to console logging if database logging fails
-      console.error('Failed to log Zoho error to database:', logError);
-      console.error('Original Zoho error:', error);
+      logger.error('Failed to log Zoho error to database:', logError);
+      logger.error('Original Zoho error:', error);
     }
   }
 
@@ -177,7 +178,7 @@ export class ZohoErrorHandler {
     try {
       // This could trigger a toast notification or in-app notification
       // For now, we'll log it as a user notification
-      console.warn('User Notification:', message);
+      logger.warn('User Notification:', message);
       
       // Could also store in a notifications table
       const userId = await this.getCurrentUserId();
@@ -195,7 +196,7 @@ export class ZohoErrorHandler {
           });
       }
     } catch (error) {
-      console.error('Failed to notify user:', error);
+      logger.error('Failed to notify user:', error);
     }
   }
 

--- a/src/services/integrations/zohoCRM/helpers.ts
+++ b/src/services/integrations/zohoCRM/helpers.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { DatabaseLead } from '@/hooks/useLeads';
 
@@ -45,7 +46,7 @@ export class ZohoHelpers {
         is_sensitive: this.checkIfSensitiveLead(zohoLead)
       };
     } catch (error) {
-      console.error('Error transforming Zoho lead:', error);
+      logger.error('Error transforming Zoho lead:', error);
       throw new Error(`Failed to transform Zoho lead ${zohoLead.id}: ${error.message}`);
     }
   }
@@ -186,7 +187,7 @@ export class ZohoHelpers {
       // Return hours since creation
       return Math.floor(diffMinutes / 60);
     } catch (error) {
-      console.error('Error calculating speed to lead:', error);
+      logger.error('Error calculating speed to lead:', error);
       return 0;
     }
   }
@@ -209,7 +210,7 @@ export class ZohoHelpers {
     try {
       return new Date(dateString);
     } catch (error) {
-      console.error('Invalid date format from Zoho:', dateString);
+      logger.error('Invalid date format from Zoho:', dateString);
       return null;
     }
   }

--- a/src/services/integrations/zohoCRM/webhooks.ts
+++ b/src/services/integrations/zohoCRM/webhooks.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { masterAIBrain } from '@/services/masterAIBrain';
@@ -27,10 +28,10 @@ export class ZohoWebhooks {
 
   async handleWebhook(payload: ZohoWebhookPayload): Promise<void> {
     try {
-      console.log('Processing Zoho webhook:', payload);
+      logger.info('Processing Zoho webhook:', payload);
 
       if (payload.module !== 'Leads') {
-        console.log('Ignoring non-lead webhook');
+        logger.info('Ignoring non-lead webhook');
         return;
       }
 
@@ -45,7 +46,7 @@ export class ZohoWebhooks {
           await this.handleLeadDeleted(payload.ids);
           break;
         default:
-          console.log(`Unhandled Zoho operation: ${payload.operation}`);
+          logger.info(`Unhandled Zoho operation: ${payload.operation}`);
       }
     } catch (error) {
       await this.errorHandler.logError(error, 'Webhook processing failed');
@@ -84,7 +85,7 @@ export class ZohoWebhooks {
 
   private async syncLeadFromZoho(leadId: string, operation: string): Promise<void> {
     try {
-      console.log(`Syncing Zoho lead ${leadId} (${operation})`);
+      logger.info(`Syncing Zoho lead ${leadId} (${operation})`);
 
       const zohoLead = await zohoAPI.getLead(leadId);
       if (!zohoLead) {
@@ -201,7 +202,7 @@ export class ZohoWebhooks {
           created_at: new Date().toISOString()
         });
     } catch (logError) {
-      console.error('Failed to log webhook activity:', logError);
+      logger.error('Failed to log webhook activity:', logError);
     }
   }
 
@@ -209,7 +210,7 @@ export class ZohoWebhooks {
     try {
       // This would set up webhooks in Zoho CRM
       // For now, return true as if successful
-      console.log('Setting up Zoho webhooks...');
+      logger.info('Setting up Zoho webhooks...');
       return true;
     } catch (error) {
       await this.errorHandler.logError(error, 'Failed to setup Zoho webhooks');
@@ -224,7 +225,7 @@ export class ZohoWebhooks {
       const expectedToken = process.env.ZOHO_WEBHOOK_TOKEN;
       return token === expectedToken;
     } catch (error) {
-      console.error('Webhook token validation failed:', error);
+      logger.error('Webhook token validation failed:', error);
       return false;
     }
   }

--- a/src/services/masterAIBrain.ts
+++ b/src/services/masterAIBrain.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { AIIngestionEvent, AIRecommendation } from './ai/types';
@@ -68,7 +69,7 @@ class MasterAIBrain {
         this.processIngestionQueue();
       }
     } catch (error) {
-      console.error('Error reloading unprocessed events:', error);
+      logger.error('Error reloading unprocessed events:', error);
     }
   }
 
@@ -137,7 +138,7 @@ class MasterAIBrain {
       }
 
     } catch (error) {
-      console.error('Error ingesting AI event:', error);
+      logger.error('Error ingesting AI event:', error);
       this.emit('ingest-error', error);
       throw error;
     }
@@ -177,7 +178,7 @@ class MasterAIBrain {
     if (this.isProcessing || this.ingestionQueue.length === 0) return;
     
     this.isProcessing = true;
-    console.log(`Processing ${this.ingestionQueue.length} AI events with hybrid AI system...`);
+    logger.info(`Processing ${this.ingestionQueue.length} AI events with hybrid AI system...`);
 
     try {
       const batchSize = 10;
@@ -189,7 +190,7 @@ class MasterAIBrain {
         await new Promise(resolve => setTimeout(resolve, 100));
       }
     } catch (error) {
-      console.error('Error processing ingestion queue:', error);
+      logger.error('Error processing ingestion queue:', error);
     } finally {
       this.isProcessing = false;
     }
@@ -219,7 +220,7 @@ class MasterAIBrain {
           .eq('id', event.id);
 
       } catch (error) {
-        console.error('Error processing event:', event, error);
+        logger.error('Error processing event:', event, error);
       }
     }
   }
@@ -242,7 +243,7 @@ class MasterAIBrain {
 
       await hybridAIOrchestrator.queueTask(analysisTask);
     } catch (error) {
-      console.error('Error in hybrid analysis:', error);
+      logger.error('Error in hybrid analysis:', error);
     }
   }
 
@@ -276,7 +277,7 @@ class MasterAIBrain {
         await emailAutomationService.evaluateAutomationTriggers(triggerType, eventData);
       }
     } catch (error) {
-      console.error('Error checking native automation triggers:', error);
+      logger.error('Error checking native automation triggers:', error);
     }
   }
 
@@ -325,7 +326,7 @@ class MasterAIBrain {
       });
 
     } catch (error) {
-      console.error('Error triggering automation:', error);
+      logger.error('Error triggering automation:', error);
       throw error;
     }
   }
@@ -357,7 +358,7 @@ class MasterAIBrain {
       });
 
     } catch (error) {
-      console.error('Error ingesting market data:', error);
+      logger.error('Error ingesting market data:', error);
     }
   }
 
@@ -379,7 +380,7 @@ class MasterAIBrain {
 
       return health;
     } catch (error) {
-      console.error('Error checking system health:', error);
+      logger.error('Error checking system health:', error);
       return {
         aiServices: 'degraded',
         learningStatus: 'error',
@@ -399,7 +400,7 @@ class MasterAIBrain {
 
       return count || 0;
     } catch (error) {
-      console.error('Error getting automation count:', error);
+      logger.error('Error getting automation count:', error);
       return 0;
     }
   }
@@ -416,7 +417,7 @@ class MasterAIBrain {
       this.performHealthCheck();
     }, 5 * 60000);
 
-    console.log('Enhanced Master Brain AI initialized with Claude integration, hybrid orchestration, and continuous learning');
+    logger.info('Enhanced Master Brain AI initialized with Claude integration, hybrid orchestration, and continuous learning');
   }
 
   private async performHealthCheck(): Promise<void> {
@@ -432,7 +433,7 @@ class MasterAIBrain {
       });
 
     } catch (error) {
-      console.error('Health check failed:', error);
+      logger.error('Health check failed:', error);
     }
   }
 }

--- a/src/services/oauth/unifiedOAuthService.ts
+++ b/src/services/oauth/unifiedOAuthService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
@@ -80,7 +81,7 @@ export class UnifiedOAuthService {
 
       return { success: false };
     } catch (error) {
-      console.error(`Failed to connect ${providerId}:`, error);
+      logger.error(`Failed to connect ${providerId}:`, error);
       toast.error(`Failed to connect ${providerId}`);
       return { success: false };
     }
@@ -102,7 +103,7 @@ export class UnifiedOAuthService {
         lastSync: data.lastSync ? new Date(data.lastSync) : undefined
       };
     } catch (error) {
-      console.error(`Failed to check ${providerId} status:`, error);
+      logger.error(`Failed to check ${providerId} status:`, error);
       return {
         provider: providerId,
         connected: false
@@ -121,7 +122,7 @@ export class UnifiedOAuthService {
       toast.success(`${providerId} disconnected successfully`);
       return { success: true };
     } catch (error) {
-      console.error(`Failed to disconnect ${providerId}:`, error);
+      logger.error(`Failed to disconnect ${providerId}:`, error);
       toast.error(`Failed to disconnect ${providerId}`);
       return { success: false };
     }
@@ -138,7 +139,7 @@ export class UnifiedOAuthService {
       toast.success(`${providerId} data synced successfully`);
       return data;
     } catch (error) {
-      console.error(`Failed to sync ${providerId} data:`, error);
+      logger.error(`Failed to sync ${providerId} data:`, error);
       toast.error(`Failed to sync ${providerId} data`);
       throw error;
     }

--- a/src/services/security/accessControlService.ts
+++ b/src/services/security/accessControlService.ts
@@ -103,7 +103,7 @@ export class AccessControlService {
     
     // In production, also send to security monitoring service
     if (severity === 'critical' || severity === 'high') {
-      console.warn(`🚨 Security Alert [${severity.toUpperCase()}]: ${event}`, details);
+      logger.warn(`🚨 Security Alert [${severity.toUpperCase()}]: ${event}`, details);
     }
   }
 

--- a/src/services/security/dataEncryptionService.ts
+++ b/src/services/security/dataEncryptionService.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 export class DataEncryptionService {
   private static instance: DataEncryptionService;
@@ -36,7 +37,7 @@ export class DataEncryptionService {
 
       return btoa(String.fromCharCode(...combined));
     } catch (error) {
-      console.error('Encryption failed:', error);
+      logger.error('Encryption failed:', error);
       try {
         const jsonString = JSON.stringify(data);
         return btoa(jsonString); // Fallback to basic encoding
@@ -58,7 +59,7 @@ export class DataEncryptionService {
       const jsonString = new TextDecoder().decode(plainBuffer);
       return JSON.parse(jsonString);
     } catch (error) {
-      console.error('Decryption failed:', error);
+      logger.error('Decryption failed:', error);
       try {
         const jsonString = atob(encryptedData);
         return JSON.parse(jsonString);

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 // Central action type definitions with string enforcement
 export const ActionTypes = {
@@ -47,7 +48,7 @@ export function validateStringParam(param: any, fallback: string): string {
   if (typeof param === 'string' && param.trim().length > 0) {
     return param;
   }
-  console.warn(`Invalid string parameter, using fallback: ${fallback}`);
+  logger.warn(`Invalid string parameter, using fallback: ${fallback}`);
   return fallback;
 }
 
@@ -55,7 +56,7 @@ export function validateAction(action: any): ActionType {
   if (typeof action === 'string' && Object.values(ActionTypes).includes(action as ActionType)) {
     return action as ActionType;
   }
-  console.warn(`Invalid action type, using default: ${ActionTypes.DEFAULT_ACTION}`);
+  logger.warn(`Invalid action type, using default: ${ActionTypes.DEFAULT_ACTION}`);
   return ActionTypes.DEFAULT_ACTION;
 }
 

--- a/src/utils/actionHandler.ts
+++ b/src/utils/actionHandler.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { ActionType, ActionTypes, ActionPayload, validateStringParam, validateAction, createSafeAction } from '@/types/actions';
 import { toast } from 'sonner';
@@ -15,7 +16,7 @@ export class SafeActionHandler {
   executeAction(action: any, data?: any, context?: string): Promise<any> {
     try {
       const safeAction = createSafeAction(action, data, context);
-      console.log('Executing safe action:', safeAction);
+      logger.info('Executing safe action:', safeAction);
 
       switch (safeAction.type) {
         case ActionTypes.AI_COMMAND:
@@ -36,7 +37,7 @@ export class SafeActionHandler {
           return this.handleDefaultAction(safeAction);
       }
     } catch (error) {
-      console.error('Action execution failed:', error);
+      logger.error('Action execution failed:', error);
       toast.error('Action failed. Please try again.');
       return Promise.resolve({ success: false, error: error.message });
     }
@@ -46,7 +47,7 @@ export class SafeActionHandler {
     const command = validateStringParam(action.data?.command, 'help');
     const context = validateStringParam(action.context, 'general');
     
-    console.log('Processing AI command:', command);
+    logger.info('Processing AI command:', command);
     
     // Implementation would go here
     return { success: true, command, context };
@@ -56,7 +57,7 @@ export class SafeActionHandler {
     const command = validateStringParam(action.data?.command, 'voice_help');
     const context = validateStringParam(action.context, 'voice');
     
-    console.log('Processing voice command:', command);
+    logger.info('Processing voice command:', command);
     
     // Implementation would go here
     return { success: true, command, context };
@@ -67,7 +68,7 @@ export class SafeActionHandler {
     const subject = validateStringParam(action.data?.subject, 'No Subject');
     const body = validateStringParam(action.data?.body, 'No Content');
     
-    console.log('Sending email:', { to, subject, body });
+    logger.info('Sending email:', { to, subject, body });
     
     // Implementation would go here
     return { success: true, to, subject, body };
@@ -77,7 +78,7 @@ export class SafeActionHandler {
     const phoneNumber = validateStringParam(action.data?.phoneNumber, '+1234567890');
     const message = validateStringParam(action.data?.message, 'Hello');
     
-    console.log('Sending SMS:', { phoneNumber, message });
+    logger.info('Sending SMS:', { phoneNumber, message });
     
     // Implementation would go here
     return { success: true, phoneNumber, message };
@@ -86,7 +87,7 @@ export class SafeActionHandler {
   private async handleNavigation(action: ActionPayload): Promise<any> {
     const path = validateStringParam(action.data?.path, '/dashboard');
     
-    console.log('Navigating to:', path);
+    logger.info('Navigating to:', path);
     
     // Implementation would go here
     return { success: true, path };
@@ -96,7 +97,7 @@ export class SafeActionHandler {
     const name = validateStringParam(action.data?.name, 'New Lead');
     const email = validateStringParam(action.data?.email, 'lead@example.com');
     
-    console.log('Creating lead:', { name, email });
+    logger.info('Creating lead:', { name, email });
     
     // Implementation would go here
     return { success: true, name, email };
@@ -106,14 +107,14 @@ export class SafeActionHandler {
     const leadId = validateStringParam(action.data?.leadId, 'default-lead-id');
     const updates = action.data?.updates || {};
     
-    console.log('Updating lead:', { leadId, updates });
+    logger.info('Updating lead:', { leadId, updates });
     
     // Implementation would go here
     return { success: true, leadId, updates };
   }
 
   private async handleDefaultAction(action: ActionPayload): Promise<any> {
-    console.log('Executing default action:', action);
+    logger.info('Executing default action:', action);
     toast.info('Action completed successfully');
     return { success: true, action: action.type };
   }

--- a/src/utils/mobileOptimization.ts
+++ b/src/utils/mobileOptimization.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 export const optimizeForMobile = (): void => {
   try {
@@ -36,8 +37,8 @@ export const optimizeForMobile = (): void => {
     // Prevent pull-to-refresh on mobile
     document.body.style.overscrollBehavior = 'none';
 
-    console.log('Mobile optimizations applied successfully');
+    logger.info('Mobile optimizations applied successfully');
   } catch (error) {
-    console.warn('Failed to apply mobile optimizations:', error);
+    logger.warn('Failed to apply mobile optimizations:', error);
   }
 };

--- a/src/utils/runtimeValidator.ts
+++ b/src/utils/runtimeValidator.ts
@@ -1,3 +1,4 @@
+import { logger } from '@/utils/logger';
 
 import { validateStringParam, ActionTypes } from '@/types/actions';
 
@@ -21,13 +22,13 @@ export class RuntimeValidator {
         if (expectedType === 'string' && typeof param !== 'string') {
           const error = `Function ${fn.name} parameter ${i} expected string but got ${typeof param}`;
           this.validationErrors.push(error);
-          console.warn(error);
+          logger.warn(error);
           return false;
         }
       }
       return true;
     } catch (error) {
-      console.error('Runtime validation error:', error);
+      logger.error('Runtime validation error:', error);
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- inject `logger` into files containing console statements
- swap `console.log`/`warn`/`error` calls for `logger` methods
- keep console references only in the logger utility and static text

## Testing
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684123c784c0832882395caf8721545d