### PR TITLE
Replace btoa/atob with Buffer

### DIFF
--- a/src/hooks/useAISecurityPosture.ts
+++ b/src/hooks/useAISecurityPosture.ts
@@ -1,5 +1,6 @@
 
 import { useState, useEffect } from 'react';
+import { encodeBase64 } from '@/services/security/base64Service';
 import { useAuth } from '@/contexts/AuthContext';
 
 interface SecurityEvent {
@@ -101,7 +102,7 @@ export const useAISecurityPosture = () => {
     // For now, basic obfuscation for demo purposes
     try {
       const jsonString = JSON.stringify(data);
-      return btoa(jsonString);
+      return encodeBase64(jsonString);
     } catch {
       return 'encryption_failed';
     }

--- a/src/hooks/voice/useAudioProcessing.ts
+++ b/src/hooks/voice/useAudioProcessing.ts
@@ -2,6 +2,7 @@
 import { useRef, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { encodeBase64 } from '@/services/security/base64Service';
 
 export const useAudioProcessing = () => {
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -61,7 +62,7 @@ export const useAudioProcessing = () => {
     try {
       // Convert audio to base64 for API
       const arrayBuffer = await audioBlob.arrayBuffer();
-      const base64Audio = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+      const base64Audio = encodeBase64(new Uint8Array(arrayBuffer));
 
       // Transcribe audio using Whisper API
       const { data: transcriptionData, error: transcriptionError } = await supabase.functions.invoke('voice-to-text', {

--- a/src/services/ai/voiceAIService.ts
+++ b/src/services/ai/voiceAIService.ts
@@ -5,6 +5,7 @@ import { elevenLabsService } from './elevenLabsService';
 import { retellAIService } from './retellAIService';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
+import { encodeBase64 } from '@/services/security/base64Service';
 
 export interface VoiceAIConfig {
   workspace: 'sales' | 'manager' | 'developer';
@@ -162,7 +163,7 @@ export class VoiceAIService {
 
   private async blobToBase64(blob: Blob): Promise<string> {
     const arrayBuffer = await blob.arrayBuffer();
-    const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+    const base64 = encodeBase64(new Uint8Array(arrayBuffer));
     return base64;
   }
 

--- a/src/services/ai/voiceService.ts
+++ b/src/services/ai/voiceService.ts
@@ -1,5 +1,6 @@
 
 import { toast } from 'sonner';
+import { encodeBase64 } from '@/services/security/base64Service';
 
 class VoiceService {
   private mediaRecorderRef: MediaRecorder | null = null;
@@ -76,7 +77,7 @@ class VoiceService {
     try {
       // Convert audio to base64 for API
       const arrayBuffer = await audioBlob.arrayBuffer();
-      const base64Audio = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+      const base64Audio = encodeBase64(new Uint8Array(arrayBuffer));
 
       // Mock transcription for now - in production this would call Whisper API
       console.log('Processing audio command...');

--- a/src/services/security/base64Service.ts
+++ b/src/services/security/base64Service.ts
@@ -1,0 +1,8 @@
+export function encodeBase64(input: string | Uint8Array): string {
+  const buffer = typeof input === 'string' ? Buffer.from(input, 'utf-8') : Buffer.from(input);
+  return buffer.toString('base64');
+}
+
+export function decodeBase64(base64: string): string {
+  return Buffer.from(base64, 'base64').toString('utf-8');
+}

--- a/src/services/security/encryptionService.ts
+++ b/src/services/security/encryptionService.ts
@@ -1,5 +1,6 @@
 
 import { logger } from '@/utils/logger';
+import { encodeBase64, decodeBase64 } from './base64Service';
 
 export class EncryptionService {
   private static instance: EncryptionService;
@@ -25,7 +26,7 @@ export class EncryptionService {
       combined.set(salt);
       combined.set(dataBytes, salt.length);
       
-      const encrypted = btoa(String.fromCharCode(...combined));
+      const encrypted = encodeBase64(String.fromCharCode(...combined));
       
       logger.info('Data encrypted successfully', { 
         dataSize: jsonString.length,
@@ -42,7 +43,7 @@ export class EncryptionService {
   async decryptSensitiveData(encryptedData: string): Promise<any> {
     try {
       const combined = new Uint8Array(
-        atob(encryptedData).split('').map(c => c.charCodeAt(0))
+        decodeBase64(encryptedData).split('').map(c => c.charCodeAt(0))
       );
       
       // Extract data after salt (first 16 bytes)
@@ -71,7 +72,7 @@ export class EncryptionService {
     // Simple hash for demo - use bcrypt or similar in production
     const encoder = new TextEncoder();
     const data = encoder.encode(value);
-    return btoa(String.fromCharCode(...data)).replace(/[^a-zA-Z0-9]/g, '').substring(0, 12);
+    return encodeBase64(String.fromCharCode(...data)).replace(/[^a-zA-Z0-9]/g, '').substring(0, 12);
   }
 }
 

--- a/supabase/functions/gmail-send/index.ts
+++ b/supabase/functions/gmail-send/index.ts
@@ -100,7 +100,7 @@ serve(async (req) => {
     ].join('\r\n')
 
     // Encode email for Gmail API
-    const encodedEmail = btoa(email)
+    const encodedEmail = Buffer.from(email).toString('base64')
       .replace(/\+/g, '-')
       .replace(/\//g, '_')
       .replace(/=+$/, '')

--- a/supabase/functions/twilio-call/index.ts
+++ b/supabase/functions/twilio-call/index.ts
@@ -43,7 +43,7 @@ serve(async (req) => {
 
     // Make Twilio API call
     const twilioUrl = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Calls.json`
-    const auth = btoa(`${accountSid}:${authToken}`)
+    const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64')
 
     const response = await fetch(twilioUrl, {
       method: 'POST',

--- a/supabase/functions/twilio-sms/index.ts
+++ b/supabase/functions/twilio-sms/index.ts
@@ -42,7 +42,7 @@ serve(async (req) => {
 
     // Send SMS via Twilio
     const twilioUrl = `https://api.twilio.com/2010-04-01/Accounts/${accountSid}/Messages.json`
-    const auth = btoa(`${accountSid}:${authToken}`)
+    const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64')
 
     const response = await fetch(twilioUrl, {
       method: 'POST',

--- a/supabase/functions/unified-oauth/index.ts
+++ b/supabase/functions/unified-oauth/index.ts
@@ -245,7 +245,7 @@ serve(async (req) => {
             method: 'POST',
             headers: { 
               'Content-Type': 'application/x-www-form-urlencoded',
-              'Authorization': `Basic ${btoa(Deno.env.get('TWITTER_CLIENT_ID') + ':' + Deno.env.get('TWITTER_CLIENT_SECRET'))}`
+              'Authorization': `Basic ${Buffer.from(Deno.env.get('TWITTER_CLIENT_ID') + ':' + Deno.env.get('TWITTER_CLIENT_SECRET')).toString('base64')}`
             },
             body: new URLSearchParams({
               code,

--- a/supabase/functions/voice-to-text/index.ts
+++ b/supabase/functions/voice-to-text/index.ts
@@ -14,7 +14,7 @@ function processBase64Chunks(base64String: string, chunkSize = 32768) {
   
   while (position < base64String.length) {
     const chunk = base64String.slice(position, position + chunkSize);
-    const binaryChunk = atob(chunk);
+    const binaryChunk = Buffer.from(chunk, 'base64').toString('utf-8');
     const bytes = new Uint8Array(binaryChunk.length);
     
     for (let i = 0; i < binaryChunk.length; i++) {


### PR DESCRIPTION
## Summary
- add a Base64 helper service
- use `encodeBase64` and `decodeBase64` in security services
- update voice hooks and services to use the helper
- switch Supabase functions to Buffer-based encoding

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684123cc3d988328999c7851dbb88b58