### PR TITLE
Update README with setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ The client now uses this function for speech synthesis instead of reading `VITE_
 
 ## Running tests
 
+Make sure the dependencies are installed first:
+
+```sh
+npm install
+```
+
 To execute the unit tests once, run:
 
 ```sh
@@ -121,4 +127,18 @@ For interactive development with automatic re-runs, use:
 
 ```sh
 npm run test:watch
+```
+
+## Linting
+
+Install the dependencies if you haven't already:
+
+```sh
+npm install
+```
+
+Then check the code style with:
+
+```sh
+npm run lint
 ```


### PR DESCRIPTION
## Summary
- clarify that dependencies must be installed before running tests or lint
- add short instructions for running linting
- keep the existing tests section with an extra install step

## Testing
- `npm install`
- `npm test` *(fails: Cannot find package 'bun:test')*

------
https://chatgpt.com/codex/tasks/task_e_68413ca1316483289f2b9197e8978e67