### PR TITLE
Handle trailing AI suggestions

### DIFF
--- a/src/services/ai/improvementParser.ts
+++ b/src/services/ai/improvementParser.ts
@@ -38,6 +38,17 @@ export function parseImprovementSuggestions(response: string): ParsedImprovement
         }
       }
     }
+
+    if (currentSuggestion.trim() && currentCategory) {
+      improvements.push({
+        category: currentCategory,
+        suggestion: currentSuggestion.trim(),
+        impact: estimateImpact(currentSuggestion),
+        implementationComplexity: estimateComplexity(currentSuggestion),
+        estimatedValue: estimateValue(currentSuggestion),
+        confidence: 0.75
+      });
+    }
   } catch (error) {
     console.error('Error parsing improvement suggestions:', error);
   }

--- a/tests/aiLearningLayer.test.js
+++ b/tests/aiLearningLayer.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { parseImprovementSuggestions } from '../src/services/ai/improvementParser';
+
+describe('parseImprovementSuggestions', () => {
+  it('captures trailing suggestion shorter than threshold', () => {
+    const response = 'UX/UI\nImprove the login page.';
+    const result = parseImprovementSuggestions(response);
+    expect(result).toEqual([
+      {
+        category: 'ux_ui',
+        suggestion: 'Improve the login page.',
+        impact: 'medium',
+        implementationComplexity: 'simple',
+        estimatedValue: 50,
+        confidence: 0.75
+      }
+    ]);
+  });
+});

--- a/tests/executionManager.test.ts
+++ b/tests/executionManager.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, vi, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ExecutionManager } from '../src/services/ai/automation/executionManager';
 import { actionExecutors } from '../src/services/ai/automation/actionExecutors';
 import type { AutomationAction } from '../src/services/ai/types/automationTypes';
 
-mock.module('../src/services/ai/automation/actionExecutors', () => ({
+vi.mock('../src/services/ai/automation/actionExecutors', () => ({
   actionExecutors: {
     executeEmailAction: vi.fn(),
     executeSmsAction: vi.fn(),


### PR DESCRIPTION
## Summary
- push the last suggestion when parsing improvements
- switch tests to use vitest
- add regression test for improvements parser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68413d11dec88328827c7b70fc3c72b5