### PR TITLE
Load encryption key from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Create a `.env` file in the project root and define the following variables used
 ELEVENLABS_API_KEY=<your-elevenlabs-key>
 SUPABASE_URL=<your-supabase-url>
 SUPABASE_SERVICE_ROLE_KEY=<your-supabase-service-role-key>
+DATA_ENCRYPTION_KEY_B64=<optional-encryption-key>
 ```
 
 These keys should be kept private and are required for the `elevenlabs-speech` function.

--- a/src/services/security/dataEncryptionService.ts
+++ b/src/services/security/dataEncryptionService.ts
@@ -6,8 +6,12 @@ export class DataEncryptionService {
   private keyPromise: Promise<CryptoKey>;
 
   private constructor() {
-    const DEFAULT_KEY_B64 = 'b4nhn4DvmRll8uXzYr5BJHVLFvyomHE4WJahSbv95Jk='; // 32-byte key
-    const keyBytes = Uint8Array.from(decodeBase64(DEFAULT_KEY_B64), c => c.charCodeAt(0));
+    const envKey =
+      (typeof process !== 'undefined' && process.env.DATA_ENCRYPTION_KEY_B64) ||
+      (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_DATA_ENCRYPTION_KEY_B64);
+
+    const keyB64 = envKey || 'b4nhn4DvmRll8uXzYr5BJHVLFvyomHE4WJahSbv95Jk='; // demo key
+    const keyBytes = Uint8Array.from(decodeBase64(keyB64), c => c.charCodeAt(0));
     this.keyPromise = crypto.subtle.importKey(
       'raw',
       keyBytes,


### PR DESCRIPTION
## Summary
- allow `DataEncryptionService` to load key from env with fallback demo key
- document `DATA_ENCRYPTION_KEY_B64` in README

## Testing
- `npm install`
- `npm test` *(fails: bun not available)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68413d1326ac8328b095bc47c4cf890a