### PR TITLE
Add vitest alias config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add `vitest.config.ts` with alias to resolve `@` to `./src`

## Testing
- `npm test` *(fails: Cannot find package 'bun:test')*

------
https://chatgpt.com/codex/tasks/task_e_68413c9f007883289324d730e2074821