### PR TITLE
Update dashboard redirect helper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { AIContextProvider } from '@/contexts/AIContext';
@@ -31,6 +33,12 @@ const queryClient = new QueryClient({
   },
 });
 
+const DashboardRedirect: React.FC = () => {
+  const { profile, isDemoMode, getLastSelectedRole } = useAuth();
+  const role = isDemoMode() ? getLastSelectedRole() : profile?.role || 'sales_rep';
+  return <Navigate to={getDashboardUrl({ role })} replace />;
+};
+
 function App() {
   console.log('App component rendering');
   
@@ -52,7 +60,7 @@ function App() {
                   <Route path="/" element={
                     <RequireAuth>
                       <OnboardingGuard>
-                        <Navigate to="/sales/dashboard" replace />
+                        <DashboardRedirect />
                       </OnboardingGuard>
                     </RequireAuth>
                   } />
@@ -113,7 +121,7 @@ function App() {
                   } />
                   
                   {/* Fallback */}
-                  <Route path="*" element={<Navigate to="/sales/dashboard" replace />} />
+                  <Route path="*" element={<DashboardRedirect />} />
                 </Routes>
                 <Toaster />
               </AIContextProvider>

--- a/src/components/DashboardRouter.tsx
+++ b/src/components/DashboardRouter.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 
 const DashboardRouter = () => {
   const { user, profile, isDemoMode, getLastSelectedRole } = useAuth();
@@ -16,30 +17,12 @@ const DashboardRouter = () => {
   // Handle demo mode
   if (isDemoMode()) {
     const demoRole = getLastSelectedRole();
-    switch (demoRole) {
-      case 'sales_rep':
-        return <Navigate to="/" replace />;
-      case 'manager':
-        return <Navigate to="/manager/dashboard" replace />;
-      case 'admin':
-        return <Navigate to="/admin-dashboard" replace />;
-      default:
-        return <Navigate to="/" replace />;
-    }
+    return <Navigate to={getDashboardUrl({ role: demoRole })} replace />;
   }
-  
+
   // Handle authenticated users based on profile role
   const role = profile?.role || 'sales_rep';
-  
-  switch (role) {
-    case 'manager':
-      return <Navigate to="/manager/dashboard" replace />;
-    case 'admin':
-      return <Navigate to="/admin-dashboard" replace />;
-    case 'sales_rep':
-    default:
-      return <Navigate to="/" replace />;
-  }
+  return <Navigate to={getDashboardUrl({ role })} replace />;
 };
 
 export default DashboardRouter;

--- a/src/components/Navigation/navigationUtils.ts
+++ b/src/components/Navigation/navigationUtils.ts
@@ -1,10 +1,13 @@
 
-import { Profile } from '@/contexts/auth/types';
+import { Profile, Role } from '@/contexts/auth/types';
 
-export const getDashboardUrl = (profile: Profile | null): string => {
-  if (!profile) return '/sales/dashboard';
-  
-  switch (profile.role) {
+export const getDashboardUrl = (
+  profileOrRole: Profile | { role: Role } | null
+): string => {
+  if (!profileOrRole) return '/sales/dashboard';
+
+  const role = profileOrRole.role;
+  switch (role) {
     case 'admin':
       return '/admin-dashboard';
     case 'manager':


### PR DESCRIPTION
## Summary
- allow `getDashboardUrl` to accept just a role
- simplify DashboardRouter using new helper
- provide DashboardRedirect component for App routing
- update root and fallback routes to use DashboardRedirect

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413d97cc6883288665928af629a679