### PR TITLE
Update Supabase functions to use shared logger

### DIFF
--- a/supabase/functions/ai-agent/index.ts
+++ b/supabase/functions/ai-agent/index.ts
@@ -1,6 +1,7 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { logger } from '../../../src/utils/logger.ts';
 
 // API Keys from environment variables
 const OPENAI_API_KEY = Deno.env.get('OPENAI_API_KEY');

--- a/supabase/functions/ai-brain-crawl/index.ts
+++ b/supabase/functions/ai-brain-crawl/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.0';
 import { encoding_for_model } from 'https://esm.sh/tiktoken-node@0.0.7';
+import { logger } from '../../../src/utils/logger.ts';
 
 // Initialize Supabase client
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';

--- a/supabase/functions/ai-brain-ingest/index.ts
+++ b/supabase/functions/ai-brain-ingest/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.0';
+import { logger } from '../../../src/utils/logger.ts';
 // Replace the missing tokenizer with tiktoken, which is available and maintained
 import { encoding_for_model } from 'https://esm.sh/tiktoken-node@0.0.7';
 

--- a/supabase/functions/ai-brain-query/index.ts
+++ b/supabase/functions/ai-brain-query/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";

--- a/supabase/functions/ai-brain-reindex/index.ts
+++ b/supabase/functions/ai-brain-reindex/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.38.0';
+import { logger } from '../../../src/utils/logger.ts';
 
 // Initialize Supabase client
 const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';

--- a/supabase/functions/ai-voice/index.ts
+++ b/supabase/functions/ai-voice/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 

--- a/supabase/functions/claude-chat/index.ts
+++ b/supabase/functions/claude-chat/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";

--- a/supabase/functions/elevenlabs-speech/index.ts
+++ b/supabase/functions/elevenlabs-speech/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { logger } from '../../../src/utils/logger.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',

--- a/supabase/functions/email-fetch/index.ts
+++ b/supabase/functions/email-fetch/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/email-oauth-callback/index.ts
+++ b/supabase/functions/email-oauth-callback/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/gmail-oauth/index.ts
+++ b/supabase/functions/gmail-oauth/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/gmail-send/index.ts
+++ b/supabase/functions/gmail-send/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/google-calendar/index.ts
+++ b/supabase/functions/google-calendar/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/openai-chat/index.ts
+++ b/supabase/functions/openai-chat/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";

--- a/supabase/functions/retell-ai/index.ts
+++ b/supabase/functions/retell-ai/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/send-lead-email/index.ts
+++ b/supabase/functions/send-lead-email/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/twilio-call/index.ts
+++ b/supabase/functions/twilio-call/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/twilio-sms/index.ts
+++ b/supabase/functions/twilio-sms/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/unified-oauth/index.ts
+++ b/supabase/functions/unified-oauth/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'

--- a/supabase/functions/voice-to-text/index.ts
+++ b/supabase/functions/voice-to-text/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../src/utils/logger.ts';
 
 import "https://deno.land/x/xhr@0.1.0/mod.ts"
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"


### PR DESCRIPTION
## Summary
- reference `src/utils/logger.ts` from all Supabase functions

## Testing
- `npm test` *(fails: vitest not found)*
- `deno cache --unsafely-ignore-certificate-errors supabase/functions/twilio-sms/index.ts`
- `deno cache --unsafely-ignore-certificate-errors supabase/functions/voice-to-text/index.ts`
- `deno cache --unsafely-ignore-certificate-errors supabase/functions/openai-chat/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_6841735ad97c83289443b58d8261da46