### PR TITLE
Use helper for dashboard redirects

### DIFF
--- a/src/components/DeveloperMode/RoleToggle.tsx
+++ b/src/components/DeveloperMode/RoleToggle.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Crown, User } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 const RoleToggle: React.FC = () => {
   const {
     user,
@@ -25,7 +26,7 @@ const RoleToggle: React.FC = () => {
       toast.success(`Switched to ${newRole.replace('_', ' ')} role`);
 
       // Redirect to appropriate dashboard
-      const redirectPath = newRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: newRole });
       window.location.href = redirectPath;
     } catch (error) {
       console.error('Error toggling role:', error);

--- a/src/components/Navigation/navigationUtils.ts
+++ b/src/components/Navigation/navigationUtils.ts
@@ -7,15 +7,12 @@ export const getDashboardUrl = (
   if (!profileOrRole) return '/sales/dashboard';
 
   const role = profileOrRole.role;
-  switch (role) {
-    case 'admin':
-      return '/admin-dashboard';
-    case 'manager':
-      return '/manager/dashboard';
-    case 'sales_rep':
-    default:
-      return '/sales/dashboard';
+
+  if (role === 'manager' || role === 'admin') {
+    return '/manager/dashboard';
   }
+
+  return '/sales/dashboard';
 };
 
 export const updateActiveItem = (pathname: string, setActiveItem: (item: string) => void) => {

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -33,21 +34,18 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
     const currentPath = window.location.pathname;
     
     if (profile.role === 'manager' && !currentPath.startsWith('/manager')) {
-      return <Navigate to="/manager/dashboard" replace />;
+      return <Navigate to={getDashboardUrl(profile)} replace />;
     }
-    
+
     if (profile.role === 'sales_rep' && !currentPath.startsWith('/sales')) {
-      return <Navigate to="/sales/dashboard" replace />;
+      return <Navigate to={getDashboardUrl(profile)} replace />;
     }
   }
 
   // Role requirement check
   if (requiredRole && profile?.role !== requiredRole) {
     // Redirect to appropriate dashboard based on role
-    if (profile?.role === 'manager') {
-      return <Navigate to="/manager/dashboard" replace />;
-    }
-    return <Navigate to="/sales/dashboard" replace />;
+    return <Navigate to={getDashboardUrl(profile)} replace />;
   }
 
   return <>{children}</>;

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -5,6 +5,7 @@ import { Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Card } from '@/components/ui/card';
 import { Role } from '@/contexts/auth/types';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 import { ThemeToggle } from '@/components/ThemeProvider';
 import Logo from '@/components/Logo';
 import AuthLoginForm from './components/AuthLoginForm';
@@ -38,7 +39,7 @@ const AuthPage = () => {
   // Redirect if already logged in
   if (user && profile && !isTransitioning) {
     console.log("AuthPage: User is logged in, redirecting based on role:", profile.role);
-    const redirectPath = profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+    const redirectPath = getDashboardUrl(profile);
     const from = location.state?.from?.pathname || redirectPath;
     return <Navigate to={from} replace />;
   }
@@ -47,7 +48,7 @@ const AuthPage = () => {
   if (isDemoMode() && !user) {
     const demoRole = localStorage.getItem('demoRole') as Role | null;
     if (demoRole) {
-      const redirectPath = demoRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: demoRole });
       console.log("AuthPage: Demo mode active, redirecting to", redirectPath);
       return <Navigate to={redirectPath} replace />;
     }
@@ -63,7 +64,7 @@ const AuthPage = () => {
     setIsTransitioning(true);
     // Simulate loading and transition to dashboard
     setTimeout(() => {
-      const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: selectedRole });
       console.log("AuthPage: Transitioning to", redirectPath);
       navigate(redirectPath, { replace: true });
       setIsTransitioning(false);

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -4,6 +4,7 @@ import { Role } from '@/contexts/auth/types';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 
 interface AuthDemoOptionsProps {
   selectedRole: Role;
@@ -36,7 +37,7 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
     setIsTransitioning(true);
     
     // Direct navigation based on role - using correct existing routes
-    const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+    const redirectPath = getDashboardUrl({ role: selectedRole });
     console.log("Redirecting to:", redirectPath);
     
     setTimeout(() => {

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -8,6 +8,7 @@ import { LogIn } from 'lucide-react';
 import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 
 interface AuthLoginFormProps {
   setIsTransitioning: (value: boolean) => void;
@@ -108,10 +109,11 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
             navigate('/onboarding');
           } else {
             // Regular navigation based on role
-            navigate('/sales/dashboard');
+            const role = companyStatus.isManager ? 'manager' : 'sales_rep';
+            navigate(getDashboardUrl({ role }));
           }
         } else {
-          navigate('/sales/dashboard');
+          navigate(getDashboardUrl({ role: 'sales_rep' }));
         }
       }, 1500);
       

--- a/tests/navigationUtils.test.ts
+++ b/tests/navigationUtils.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { getDashboardUrl } from '../src/components/Navigation/navigationUtils';
+
+const managerProfile = { role: 'manager' } as any;
+const salesProfile = { role: 'sales_rep' } as any;
+const adminProfile = { role: 'admin' } as any;
+
+describe('getDashboardUrl', () => {
+  it('returns manager dashboard for manager role', () => {
+    expect(getDashboardUrl(managerProfile)).toBe('/manager/dashboard');
+  });
+
+  it('returns sales dashboard for sales rep role', () => {
+    expect(getDashboardUrl(salesProfile)).toBe('/sales/dashboard');
+  });
+
+  it('treats admin role as manager dashboard', () => {
+    expect(getDashboardUrl(adminProfile)).toBe('/manager/dashboard');
+  });
+
+  it('defaults to sales dashboard when profile is null', () => {
+    expect(getDashboardUrl(null)).toBe('/sales/dashboard');
+  });
+});


### PR DESCRIPTION
## Summary
- simplify `getDashboardUrl` logic
- use helper for all dashboard redirects
- test new behaviour of `getDashboardUrl`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841733019d08328a228b6480257048b