### PR TITLE
Ensure logout waits for signOut

### DIFF
--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -20,13 +20,12 @@ export interface UserProfileProps {
 }
 
 const UserProfile: React.FC<UserProfileProps> = ({ name, role }) => {
-  const { user } = useAuth();
+  const { signOut } = useAuth();
 
   const handleLogout = async () => {
     try {
-      // For now, we'll just redirect to auth page
-      // The AuthContext might not have a logout method yet
       logger.info('Logout requested');
+      await signOut();
       window.location.href = '/auth';
     } catch (error) {
       logger.error('Logout failed:', error);


### PR DESCRIPTION
## Summary
- await `signOut` within UserProfile logout handler
- show other components already calling `signOut`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841bda6adc08328b7d0453ebde72158