### PR TITLE
Add missing Manager dashboard tab components

### DIFF
--- a/src/components/Manager/KnowledgeTab.tsx
+++ b/src/components/Manager/KnowledgeTab.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Upload, Search, RefreshCw } from 'lucide-react';
+
+const KnowledgeTab: React.FC = () => {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Upload className="h-5 w-5" />
+            Knowledge Upload
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Add documents or URLs to build your company knowledge base.
+          </p>
+          <Button size="sm">Upload Content</Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Search className="h-5 w-5" />
+            Knowledge Search
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-gray-600">
+            Quickly search through all indexed material and refresh when needed.
+          </p>
+          <Button variant="outline" size="sm">
+            Reindex
+            <RefreshCw className="h-4 w-4 ml-2" />
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default KnowledgeTab;

--- a/src/components/Manager/LeadAssignment.tsx
+++ b/src/components/Manager/LeadAssignment.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Users, UserPlus } from 'lucide-react';
+
+const LeadAssignment: React.FC = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5" />
+          Lead Assignment
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-gray-600">Automatically distribute new leads to your team.</p>
+        <Button size="sm">
+          Assign Leads
+          <UserPlus className="h-4 w-4 ml-2" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default LeadAssignment;

--- a/src/components/Manager/MarketingAnalytics.tsx
+++ b/src/components/Manager/MarketingAnalytics.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { BarChart3, RefreshCw } from 'lucide-react';
+
+const MarketingAnalytics: React.FC = () => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <BarChart3 className="h-5 w-5" />
+          Marketing Analytics
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-gray-600">
+          View campaign performance and audience engagement metrics.
+        </p>
+        <Button variant="outline" size="sm">
+          Refresh Data
+          <RefreshCw className="h-4 w-4 ml-2" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MarketingAnalytics;


### PR DESCRIPTION
## Summary
- add placeholder Manager dashboard components for Knowledge, Marketing Analytics, and Lead Assignment

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841c3164d9c8328bfb456769be8833c