### PR TITLE
Fix consecutive missed call count usage

### DIFF
--- a/src/components/AutoDialer/AutoDialerSystem.tsx
+++ b/src/components/AutoDialer/AutoDialerSystem.tsx
@@ -109,13 +109,15 @@ const AutoDialerSystem: React.FC<AutoDialerSystemProps> = ({ leads, onLeadSelect
   };
 
   const handleCallMissed = () => {
-    setConsecutiveMissed(prev => prev + 1);
-    
-    if (consecutiveMissed >= 9) {
-      aiReorderQueue();
-      toast.info('AI is reordering queue based on recent patterns');
-    }
-    
+    setConsecutiveMissed(prev => {
+      const newCount = prev + 1;
+      if (newCount >= 10) {
+        aiReorderQueue();
+        toast.info('AI is reordering queue based on recent patterns');
+      }
+      return newCount;
+    });
+
     handleEndCall();
   };
 


### PR DESCRIPTION
## Summary
- ensure `handleCallMissed` uses the updated state value returned from `setConsecutiveMissed`

## Testing
- `npx vitest`

------
https://chatgpt.com/codex/tasks/task_e_68423b8ca7b0832899f27daccfe15568