### PR TITLE
Add Twilio webhook handlers and UI call status updates

### DIFF
--- a/src/hooks/useCallStatus.ts
+++ b/src/hooks/useCallStatus.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { logger } from '@/utils/logger';
+
+export const useCallStatus = (callSid?: string) => {
+  const [status, setStatus] = useState<string>();
+  const [duration, setDuration] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!callSid) return;
+
+    const channel = supabase
+      .channel(`call-status-${callSid}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'call_logs',
+          filter: `call_sid=eq.${callSid}`
+        },
+        payload => {
+          setStatus(payload.new.status);
+          setDuration(payload.new.duration);
+          logger.info('Call status update:', payload.new.status);
+          if (payload.new.status === 'completed') {
+            toast.success('Call completed');
+          } else if (payload.new.status === 'failed') {
+            toast.error('Call failed');
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [callSid]);
+
+  return { status, duration };
+};

--- a/supabase/functions/call-status/index.ts
+++ b/supabase/functions/call-status/index.ts
@@ -1,0 +1,45 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    const form = await req.formData();
+    const callSid = form.get('CallSid')?.toString();
+    const callStatus = form.get('CallStatus')?.toString();
+    const callDuration = form.get('CallDuration');
+
+    if (!callSid || !callStatus) {
+      throw new Error('Missing call SID or status');
+    }
+
+    await supabaseClient
+      .from('call_logs')
+      .update({
+        status: callStatus,
+        duration: callDuration ? Number(callDuration) : undefined,
+      })
+      .eq('call_sid', callSid);
+
+    return new Response('OK', { headers: corsHeaders });
+  } catch (error) {
+    console.error('Error in call-status webhook:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});

--- a/supabase/functions/recording-status/index.ts
+++ b/supabase/functions/recording-status/index.ts
@@ -1,0 +1,41 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    const form = await req.formData();
+    const callSid = form.get('CallSid')?.toString();
+    const recordingUrl = form.get('RecordingUrl')?.toString();
+
+    if (!callSid) {
+      throw new Error('Missing call SID');
+    }
+
+    await supabaseClient
+      .from('call_logs')
+      .update({ recording_url: recordingUrl ?? undefined })
+      .eq('call_sid', callSid);
+
+    return new Response('OK', { headers: corsHeaders });
+  } catch (error) {
+    console.error('Error in recording-status webhook:', error);
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add `call-status` and `recording-status` functions to accept Twilio webhooks
- log new call events when initiating a call
- create `useCallStatus` hook for realtime updates
- show live call status in `LeadCallTab`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423b8da4f48328bc3b232c832eb908