### PR TITLE
Add React tests for call actions

### DIFF
--- a/src/__tests__/dialerInteractions.test.tsx
+++ b/src/__tests__/dialerInteractions.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import type { Lead } from '@/types/lead';
+
+// Mocks for hooks used across tests. Implementations are replaced in each test.
+let makeCallMock = vi.fn();
+let sendSMSMock = vi.fn();
+let sendEmailMock = vi.fn();
+
+vi.mock('@/hooks/useIntegrations', () => ({
+  useIntegrations: () => ({
+    makeCall: makeCallMock,
+    sendSMS: sendSMSMock,
+    sendEmail: sendEmailMock,
+    isLoading: false
+  })
+}));
+
+let makeConversationalCallMock = vi.fn();
+
+vi.mock('@/hooks/useRetellAI', () => ({
+  useRetellAI: () => ({
+    makeConversationalCall: makeConversationalCallMock,
+    isLoading: false
+  })
+}));
+
+import LeadCallTab from '@/components/LeadWorkspace/tabs/LeadCallTab';
+import CallInterface from '@/components/AutoDialer/CallInterface';
+import DialerQueue from '@/components/AutoDialer/DialerQueue';
+
+beforeEach(() => {
+  makeCallMock = vi.fn().mockResolvedValue({ success: true });
+  sendSMSMock = vi.fn().mockResolvedValue({ success: true });
+  sendEmailMock = vi.fn().mockResolvedValue({ success: true });
+  makeConversationalCallMock = vi.fn().mockResolvedValue({ success: true });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const baseLead: Lead = {
+  id: '1',
+  name: 'John Doe',
+  email: 'john@example.com',
+  phone: '1234567890',
+  company: 'Acme',
+  status: 'new',
+  priority: 'high',
+  source: 'web',
+  score: 90,
+  conversionLikelihood: 80,
+  lastContact: '',
+  speedToLead: 5,
+  tags: [],
+  createdAt: '',
+  updatedAt: '',
+  companyId: 'c1',
+  isSensitive: false
+};
+
+it('initiates call with correct parameters', () => {
+  render(<LeadCallTab lead={baseLead} />);
+  const btn = screen.getByRole('button', { name: /manual call/i });
+  fireEvent.click(btn);
+  expect(makeCallMock).toHaveBeenCalledWith(baseLead.phone, baseLead.id, baseLead.name);
+});
+
+it('sends SMS and email with proper parameters', async () => {
+  render(
+    <CallInterface
+      lead={baseLead}
+      callDuration={0}
+      isMuted={false}
+      onMuteToggle={() => {}}
+      onCallOutcome={() => {}}
+      aiAssistantActive={false}
+    />
+  );
+
+  // SMS action
+  fireEvent.click(screen.getByRole('button', { name: /^sms$/i }));
+  const smsArea = screen.getByPlaceholderText('Type your SMS message...');
+  fireEvent.change(smsArea, { target: { value: 'hello' } });
+  fireEvent.click(screen.getByRole('button', { name: /send sms/i }));
+  expect(sendSMSMock).toHaveBeenCalledWith(baseLead.phone, 'hello', baseLead.id, baseLead.name);
+
+  // Email action
+  fireEvent.click(screen.getByRole('button', { name: /^email$/i }));
+  const emailArea = screen.getByPlaceholderText('Compose your follow-up email...');
+  fireEvent.change(emailArea, { target: { value: 'hi there' } });
+  fireEvent.click(screen.getByRole('button', { name: /send email/i }));
+  expect(sendEmailMock).toHaveBeenCalledWith(
+    baseLead.email,
+    'Follow-up from our call',
+    'hi there',
+    baseLead.id,
+    baseLead.name
+  );
+});
+
+it('calls queue transition handler', () => {
+  const move = vi.fn();
+  render(
+    <DialerQueue
+      repQueue={[baseLead]}
+      aiQueue={[]}
+      currentLead={null}
+      onMoveLeadBetweenQueues={move}
+      onLeadSelect={() => {}}
+    />
+  );
+
+  fireEvent.click(screen.getByTestId('move-to-ai'));
+  expect(move).toHaveBeenCalledWith(baseLead.id, 'rep', 'ai');
+});

--- a/src/components/AutoDialer/DialerQueue.tsx
+++ b/src/components/AutoDialer/DialerQueue.tsx
@@ -61,31 +61,33 @@ const DialerQueue: React.FC<DialerQueueProps> = ({
           {lead.priority === 'high' && <Star className="h-3 w-3 text-yellow-500 fill-yellow-500" />}
         </div>
         <div className="flex gap-1">
-          {queueType === 'rep' ? (
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-6 w-6 p-0"
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveLeadBetweenQueues(lead.id, 'rep', 'ai');
-              }}
-            >
-              <ArrowRight className="h-3 w-3" />
-            </Button>
-          ) : (
-            <Button
-              size="sm"
-              variant="ghost"
-              className="h-6 w-6 p-0"
-              onClick={(e) => {
-                e.stopPropagation();
-                onMoveLeadBetweenQueues(lead.id, 'ai', 'rep');
-              }}
-            >
-              <ArrowLeft className="h-3 w-3" />
-            </Button>
-          )}
+            {queueType === 'rep' ? (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 w-6 p-0"
+                data-testid="move-to-ai"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMoveLeadBetweenQueues(lead.id, 'rep', 'ai');
+                }}
+              >
+                <ArrowRight className="h-3 w-3" />
+              </Button>
+            ) : (
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-6 w-6 p-0"
+                data-testid="move-to-rep"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMoveLeadBetweenQueues(lead.id, 'ai', 'rep');
+                }}
+              >
+                <ArrowLeft className="h-3 w-3" />
+              </Button>
+            )}
         </div>
       </div>
       


### PR DESCRIPTION
## Summary
- add data-testid attributes for queue buttons
- create dialer interaction tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423b8d48dc832888e4d49fe4a48577