### PR TITLE
Include lead ID and user when starting AI calls

### DIFF
--- a/src/hooks/useRetellAI.ts
+++ b/src/hooks/useRetellAI.ts
@@ -2,6 +2,8 @@
 import { useState } from 'react';
 import { Lead } from '@/types/lead';
 import { toast } from 'sonner';
+import { useAuth } from '@/contexts/AuthContext';
+import { voiceAIService } from '@/services/ai/voiceAIService';
 
 interface RetellCallResult {
   success: boolean;
@@ -11,29 +13,32 @@ interface RetellCallResult {
 
 export const useRetellAI = () => {
   const [isLoading, setIsLoading] = useState(false);
+  const { user } = useAuth();
 
   const makeConversationalCall = async (lead: Lead): Promise<RetellCallResult> => {
+    if (!user?.id) {
+      toast.error('Authentication required');
+      return { success: false, error: 'Not authenticated' };
+    }
+
     setIsLoading(true);
-    
+
     try {
-      // Simulate API call to Retell AI
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      const callId = `retell_${Date.now()}`;
-      
-      // Mock successful call initiation
-      toast.success(`AI conversation initiated with ${lead.name}`);
-      
+      const result = await voiceAIService.initiateAICall(
+        lead.phone,
+        lead.id,
+        lead.name,
+        user.id,
+        lead
+      );
+
       setIsLoading(false);
-      return {
-        success: true,
-        callId
-      };
+      return result;
     } catch (error) {
       setIsLoading(false);
       return {
         success: false,
-        error: 'Failed to initiate AI call'
+        error: error instanceof Error ? error.message : 'Failed to initiate AI call'
       };
     }
   };

--- a/src/services/ai/retellAIService.ts
+++ b/src/services/ai/retellAIService.ts
@@ -20,8 +20,10 @@ export interface RetellAgentConfig {
 
 export interface RetellCallOptions {
   phoneNumber: string;
+  leadId: string;
   leadName: string;
   leadContext: any;
+  userId: string;
   agentConfig?: Partial<RetellAgentConfig>;
 }
 
@@ -97,10 +99,12 @@ export class RetellAIService {
 
       if (error) throw error;
 
-      logger.info('Retell AI call initiated', { 
-        callId: data.callId, 
+      logger.info('Retell AI call initiated', {
+        callId: data.callId,
         phoneNumber: options.phoneNumber,
-        leadName: options.leadName 
+        leadName: options.leadName,
+        leadId: options.leadId,
+        userId: options.userId
       }, 'retell_ai');
 
       toast.success(`AI Assistant is calling ${options.leadName}...`);

--- a/src/services/ai/voiceAIService.ts
+++ b/src/services/ai/voiceAIService.ts
@@ -126,11 +126,19 @@ export class VoiceAIService {
     }
   }
 
-  async initiateAICall(phoneNumber: string, leadName: string, leadContext: any): Promise<{ success: boolean; callId?: string }> {
+  async initiateAICall(
+    phoneNumber: string,
+    leadId: string,
+    leadName: string,
+    userId: string,
+    leadContext: any
+  ): Promise<{ success: boolean; callId?: string }> {
     try {
       const result = await retellAIService.initiateCall({
         phoneNumber,
+        leadId,
         leadName,
+        userId,
         leadContext,
         agentConfig: {
           agent_name: `Sales AI for ${leadName}`,


### PR DESCRIPTION
## Summary
- pull user id from `useAuth` in `useRetellAI`
- update `voiceAIService.initiateAICall` signature to accept lead and user IDs
- include `leadId` and `userId` when calling Supabase in `retellAIService`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684248f3d2088328914c42cc46320203