### PR TITLE
Fix CORS default origin logic

### DIFF
--- a/supabase/functions/ai-agent/index.ts
+++ b/supabase/functions/ai-agent/index.ts
@@ -237,7 +237,9 @@ async function callAIWithFallback(systemPrompt: string, userPrompt: string, pref
 serve(async (req) => {
   const corsHeaders = {
     'Access-Control-Allow-Origin':
-      allowedOrigins.includes(req.headers.get('origin') ?? '')
+      allowedOrigins.length === 0
+        ? '*'
+        : allowedOrigins.includes(req.headers.get('origin') ?? '')
         ? req.headers.get('origin') ?? ''
         : allowedOrigins[0] ?? '',
     'Access-Control-Allow-Headers':

--- a/supabase/functions/retell-ai/index.ts
+++ b/supabase/functions/retell-ai/index.ts
@@ -28,7 +28,9 @@ interface RetellWebhookEvent {
 serve(async (req) => {
   const corsHeaders = {
     'Access-Control-Allow-Origin':
-      allowedOrigins.includes(req.headers.get('origin') ?? '')
+      allowedOrigins.length === 0
+        ? '*'
+        : allowedOrigins.includes(req.headers.get('origin') ?? '')
         ? req.headers.get('origin') ?? ''
         : allowedOrigins[0] ?? '',
     'Access-Control-Allow-Headers':


### PR DESCRIPTION
## Summary
- default `Access-Control-Allow-Origin` to `*` when no origins are configured
- apply change to ai-agent and retell-ai functions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684248f42e7883289a8cd60b0baa2e48