### PR TITLE
Add Supabase training storage

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1248,6 +1248,42 @@ export type Database = {
         }
         Relationships: []
       }
+      ai_agent_training: {
+        Row: {
+          id: string
+          user_id: string
+          call_id: string | null
+          snippet: string | null
+          rating: number | null
+          voice_settings: Json | null
+          script_templates: Json | null
+          created_at: string | null
+          updated_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          call_id?: string | null
+          snippet?: string | null
+          rating?: number | null
+          voice_settings?: Json | null
+          script_templates?: Json | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          call_id?: string | null
+          snippet?: string | null
+          rating?: number | null
+          voice_settings?: Json | null
+          script_templates?: Json | null
+          created_at?: string | null
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       user_notifications: {
         Row: {
           created_at: string | null

--- a/supabase/migrations/20250526_create_ai_agent_training.sql
+++ b/supabase/migrations/20250526_create_ai_agent_training.sql
@@ -1,0 +1,15 @@
+-- Table to store AI agent voice settings, script templates and rep feedback
+CREATE TABLE IF NOT EXISTS public.ai_agent_training (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  call_id uuid REFERENCES public.call_logs(id),
+  snippet text,
+  rating smallint,
+  voice_settings jsonb,
+  script_templates jsonb,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+-- Index for quickly fetching a user's settings
+CREATE UNIQUE INDEX IF NOT EXISTS ai_agent_training_user_idx ON public.ai_agent_training(user_id) WHERE call_id IS NULL;


### PR DESCRIPTION
## Summary
- create `ai_agent_training` table
- save voice configuration to Supabase
- let reps tag call snippets with rating
- load saved voice settings on mount

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684248f6a63c8328bd160d1b6f2e591f