### PR TITLE
Update signIn to load profile immediately

### DIFF
--- a/src/contexts/auth/types.ts
+++ b/src/contexts/auth/types.ts
@@ -23,10 +23,13 @@ export interface AuthContextType {
   profile: Profile | null;
   session: Session | null;
   loading: boolean;
-  signIn: (email: string, password: string) => Promise<{ error?: AuthError }>;
+  signIn: (
+    email: string,
+    password: string
+  ) => Promise<{ profile?: Profile; error?: AuthError }>;
   signUp: (email: string, password: string, metadata?: any) => Promise<{ error?: AuthError }>;
   signOut: () => Promise<void>;
-  fetchProfile: (userId: string) => Promise<void>;
+  fetchProfile: (userId: string) => Promise<Profile | null>;
   isDemoMode: () => boolean;
   setLastSelectedRole: (role: Role) => void;
   getLastSelectedRole: () => Role;


### PR DESCRIPTION
## Summary
- return fetched profile from `signIn`
- make `fetchProfile` return the profile
- persist `lastSelectedRole` after login

## Testing
- `npm run lint` *(fails: Parsing errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684256fd431c8328bf18b92d76df99f0