### PR TITLE
Add role/company selector post-login

### DIFF
--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -203,6 +203,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     return (localStorage.getItem('lastSelectedRole') as Role) || 'sales_rep';
   };
 
+  const setLastSelectedCompanyId = (companyId: string): void => {
+    localStorage.setItem('lastSelectedCompanyId', companyId);
+  };
+
+  const getLastSelectedCompanyId = (): string | null => {
+    return localStorage.getItem('lastSelectedCompanyId');
+  };
+
   const initializeDemoMode = (role: Role): void => {
     localStorage.setItem('demoMode', 'true');
     localStorage.setItem('demoRole', role);
@@ -222,6 +230,8 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     isDemoMode,
     setLastSelectedRole,
     getLastSelectedRole,
+    setLastSelectedCompanyId,
+    getLastSelectedCompanyId,
     initializeDemoMode
   };
 

--- a/src/contexts/auth/localStorage.ts
+++ b/src/contexts/auth/localStorage.ts
@@ -8,3 +8,11 @@ export const setLastSelectedRole = (role: Role): void => {
 export const getLastSelectedRole = (): Role => {
   return (localStorage.getItem('lastSelectedRole') as Role) || 'sales_rep';
 };
+
+export const setLastSelectedCompanyId = (companyId: string): void => {
+  localStorage.setItem('lastSelectedCompanyId', companyId);
+};
+
+export const getLastSelectedCompanyId = (): string | null => {
+  return localStorage.getItem('lastSelectedCompanyId');
+};

--- a/src/contexts/auth/types.ts
+++ b/src/contexts/auth/types.ts
@@ -30,5 +30,7 @@ export interface AuthContextType {
   isDemoMode: () => boolean;
   setLastSelectedRole: (role: Role) => void;
   getLastSelectedRole: () => Role;
+  setLastSelectedCompanyId: (companyId: string) => void;
+  getLastSelectedCompanyId: () => string | null;
   initializeDemoMode: (role: Role) => void;
 }

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -12,6 +12,7 @@ import AuthLoginForm from './components/AuthLoginForm';
 import AuthSignupForm from './components/AuthSignupForm';
 import AuthDemoOptions from './components/AuthDemoOptions';
 import AuthLoadingScreen from './components/AuthLoadingScreen';
+import RoleCompanySelector from './RoleCompanySelector';
 
 const AuthPage = () => {
   const { user, profile, loading, setLastSelectedRole, getLastSelectedRole, initializeDemoMode, isDemoMode } = useAuth();
@@ -36,8 +37,16 @@ const AuthPage = () => {
     );
   }
 
-  // Redirect if already logged in
+  // Redirect or prompt for selection if already logged in
   if (user && profile && !isTransitioning) {
+    const profileAny = profile as any;
+    const hasMultipleCompanies = Array.isArray(profileAny?.companies) && profileAny.companies.length > 1;
+    const hasMultipleRoles = Array.isArray(profileAny?.roles) && profileAny.roles.length > 1;
+
+    if (hasMultipleCompanies || hasMultipleRoles) {
+      return <RoleCompanySelector />;
+    }
+
     logger.info("AuthPage: User is logged in, redirecting based on role:", profile.role);
     const redirectPath = profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
     const from = location.state?.from?.pathname || redirectPath;

--- a/src/pages/auth/RoleCompanySelector.tsx
+++ b/src/pages/auth/RoleCompanySelector.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { Role } from '@/contexts/auth/types';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
+
+interface Option {
+  role: Role;
+  company_id: string;
+  company_name?: string;
+}
+
+const RoleCompanySelector: React.FC = () => {
+  const { user, setLastSelectedRole, setLastSelectedCompanyId } = useAuth();
+  const navigate = useNavigate();
+  const [options, setOptions] = useState<Option[]>([]);
+
+  useEffect(() => {
+    const fetchOptions = async () => {
+      if (!user) return;
+      const { data, error } = await supabase
+        .from('user_company_roles')
+        .select('role, company_id, company:company_id(name)')
+        .eq('user_id', user.id);
+      if (error) {
+        console.error('Error fetching role/company options', error);
+        return;
+      }
+      if (data && Array.isArray(data)) {
+        const opts = data.map((d: any) => ({
+          role: d.role as Role,
+          company_id: d.company_id,
+          company_name: d.company?.name || d.company_name || d.company_id,
+        }));
+        setOptions(opts);
+        if (opts.length === 1) {
+          handleSelect(opts[0]);
+        }
+      }
+    };
+    fetchOptions();
+  }, [user]);
+
+  const handleSelect = (opt: Option) => {
+    setLastSelectedRole(opt.role);
+    setLastSelectedCompanyId(opt.company_id);
+    const url = getDashboardUrl({ role: opt.role });
+    navigate(url, { replace: true });
+  };
+
+  if (options.length <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background to-muted/80 dark:from-dark dark:to-dark/90">
+      <Card className="max-w-md w-full p-6 space-y-4">
+        <CardHeader>
+          <CardTitle>Select Company & Role</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {options.map((o) => (
+            <Button key={`${o.company_id}-${o.role}`} className="w-full" onClick={() => handleSelect(o)}>
+              {o.company_name} – {o.role.replace('_', ' ')}
+            </Button>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default RoleCompanySelector;


### PR DESCRIPTION
## Summary
- extend auth context to track selected company
- add RoleCompanySelector page
- show role/company selection in AuthPage when multiple options are present

## Testing
- `npm run lint` *(fails: Parsing error: Merge conflict marker encountered)*
- `npm test` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684256fea2188328aa638640d320beea