### PR TITLE
Fix signup role metadata

### DIFF
--- a/src/pages/auth/components/AuthSignupForm.tsx
+++ b/src/pages/auth/components/AuthSignupForm.tsx
@@ -7,8 +7,10 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from 'sonner';
 
+import { Role } from '@/contexts/auth/types';
+
 interface AuthSignupFormProps {
-  selectedRole?: string;
+  selectedRole?: Role;
   setIsLogin?: (value: boolean) => void;
 }
 
@@ -29,7 +31,7 @@ const AuthSignupForm: React.FC<AuthSignupFormProps> = ({ selectedRole, setIsLogi
 
     setIsLoading(true);
     try {
-      const { error } = await signUp(email, password);
+      const { error } = await signUp(email, password, { role: selectedRole });
       if (error) {
         toast.error(error.message);
       } else {


### PR DESCRIPTION
## Summary
- pass selected role to signup for proper profile creation

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6842916dcf0c8328a28150d2ce8b4254