### PR TITLE
Fix login fallback when Supabase missing

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -5,6 +5,8 @@ import { createClient } from '@supabase/supabase-js';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+export const isSupabaseConfigured = !!supabaseUrl && !!supabaseKey;
+
 if (!supabaseUrl || !supabaseKey) {
   logger.warn('Supabase credentials not found, using demo mode');
 }


### PR DESCRIPTION
## Summary
- export `isSupabaseConfigured` from Supabase client
- use local demo user when Supabase credentials are missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684295bfb9ec8328b36f5d0e56b7b3e5