### PR TITLE
Add manager tabs and routes

### DIFF
--- a/src/components/Navigation/ManagerNavigation.tsx
+++ b/src/components/Navigation/ManagerNavigation.tsx
@@ -1,7 +1,16 @@
 
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { BarChart3, Users, Settings, Brain, Building2, Database } from 'lucide-react';
+import {
+  BarChart3,
+  Users,
+  Settings,
+  Brain,
+  Building2,
+  Database,
+  Shield,
+  FileText
+} from 'lucide-react';
 import Logo from '@/components/Logo';
 import UserProfile from '@/components/UserProfile';
 import { ThemeToggle } from '@/components/ThemeToggle';
@@ -17,6 +26,10 @@ const ManagerNavigation = () => {
     { label: 'Lead Management', href: '/manager/lead-management', icon: Users },
     { label: 'Company Brain', href: '/manager/company-brain', icon: Database },
     { label: 'AI Assistant', href: '/manager/ai', icon: Brain },
+    { label: 'CRM Integrations', href: '/manager/crm-integrations', icon: Database },
+    { label: 'Team Management', href: '/manager/team-management', icon: Users },
+    { label: 'Security', href: '/manager/security', icon: Shield },
+    { label: 'Reports', href: '/manager/reports', icon: FileText },
     { label: 'Settings', href: '/manager/settings', icon: Settings },
   ];
 

--- a/src/layouts/ManagerLayout.tsx
+++ b/src/layouts/ManagerLayout.tsx
@@ -9,6 +9,10 @@ import ManagerAnalytics from '@/pages/manager/Analytics';
 import ManagerLeadManagement from '@/pages/manager/LeadManagement';
 import ManagerCompanyBrain from '@/pages/manager/CompanyBrain';
 import ManagerAI from '@/pages/manager/AI';
+import ManagerCRMIntegrations from '@/pages/manager/CRMIntegrations';
+import TeamManagement from '@/pages/manager/TeamManagement';
+import SecurityPage from '@/pages/manager/Security';
+import Reports from '@/pages/manager/Reports';
 import ManagerSettings from '@/pages/manager/Settings';
 
 import UnifiedAIBubble from '@/components/UnifiedAI/UnifiedAIBubble';
@@ -55,6 +59,10 @@ const ManagerLayout = () => {
           <Route path="/lead-management" element={<ManagerLeadManagement />} />
           <Route path="/company-brain" element={<ManagerCompanyBrain />} />
           <Route path="/ai" element={<ManagerAI />} />
+          <Route path="/crm-integrations" element={<ManagerCRMIntegrations />} />
+          <Route path="/team-management" element={<TeamManagement />} />
+          <Route path="/security" element={<SecurityPage />} />
+          <Route path="/reports" element={<Reports />} />
           <Route path="/settings" element={<ManagerSettings />} />
           <Route path="*" element={<Navigate to="/dashboard" replace />} />
         </Routes>


### PR DESCRIPTION
## Summary
- add icons for extra manager pages and extend nav items
- add routes in ManagerLayout for CRMIntegrations, TeamManagement, Security and Reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842de2990408328a78b687013a2e350