### PR TITLE
Add Inter, Manrope & Poppins fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,12 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
     <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Manrope:wght@400;500;600;700&family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,9 +20,11 @@ export default {
 			}
 		},
 		extend: {
-			fontFamily: {
-				inter: ['Inter', 'sans-serif'],
-			},
+                        fontFamily: {
+                                inter: ['Inter', 'sans-serif'],
+                                manrope: ['Manrope', 'sans-serif'],
+                                poppins: ['Poppins', 'sans-serif'],
+                        },
 			colors: {
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',


### PR DESCRIPTION
## Summary
- include Google Fonts links in `index.html`
- set up `manrope` and `poppins` Tailwind font families

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f5efd9b88328996f5485e23fee62