### PR TITLE
Replace emoji icons with lucide-react

### DIFF
--- a/src/components/LeadWorkspace/LeadWorkspaceCenter.tsx
+++ b/src/components/LeadWorkspace/LeadWorkspaceCenter.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Switch } from '@/components/ui/switch';
-import { Brain } from 'lucide-react';
+import { Brain, StickyNote, Mail, PhoneCall, MessageCircle, Calendar } from 'lucide-react';
 import { DatabaseLead } from '@/hooks/useLeads';
 import LeadOverviewTab from './tabs/LeadOverviewTab';
 import LeadNotesTab from './tabs/LeadNotesTab';
@@ -73,12 +73,24 @@ const LeadWorkspaceCenter: React.FC<LeadWorkspaceCenterProps> = ({
       <Tabs value={activeTab} onValueChange={onTabChange} className="flex-1 flex flex-col">
         <div className="border-b px-6 bg-white">
           <TabsList className="grid w-full grid-cols-6">
-            <TabsTrigger value="overview">🧠 Overview</TabsTrigger>
-            <TabsTrigger value="notes">📋 Notes</TabsTrigger>
-            <TabsTrigger value="email">📨 Email</TabsTrigger>
-            <TabsTrigger value="call">📞 Call</TabsTrigger>
-            <TabsTrigger value="sms">💬 SMS</TabsTrigger>
-            <TabsTrigger value="meetings">📆 Meetings</TabsTrigger>
+            <TabsTrigger value="overview" className="flex items-center gap-1">
+              <Brain className="h-3 w-3" /> Overview
+            </TabsTrigger>
+            <TabsTrigger value="notes" className="flex items-center gap-1">
+              <StickyNote className="h-3 w-3" /> Notes
+            </TabsTrigger>
+            <TabsTrigger value="email" className="flex items-center gap-1">
+              <Mail className="h-3 w-3" /> Email
+            </TabsTrigger>
+            <TabsTrigger value="call" className="flex items-center gap-1">
+              <PhoneCall className="h-3 w-3" /> Call
+            </TabsTrigger>
+            <TabsTrigger value="sms" className="flex items-center gap-1">
+              <MessageCircle className="h-3 w-3" /> SMS
+            </TabsTrigger>
+            <TabsTrigger value="meetings" className="flex items-center gap-1">
+              <Calendar className="h-3 w-3" /> Meetings
+            </TabsTrigger>
           </TabsList>
         </div>
 

--- a/src/components/LeadWorkspace/LeadWorkspaceRight.tsx
+++ b/src/components/LeadWorkspace/LeadWorkspaceRight.tsx
@@ -8,9 +8,13 @@ import {
   ChevronLeft, 
   ChevronRight, 
   TrendingUp, 
-  Clock, 
+  Clock,
   Target,
   FileText,
+  BarChart2,
+  Video,
+  PhoneCall,
+  Lightbulb,
   Send,
   Zap,
   Calculator,
@@ -229,14 +233,17 @@ const LeadWorkspaceRight: React.FC<LeadWorkspaceRightProps> = ({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-2">
-            <div className="text-sm text-slate-600 hover:text-slate-900 cursor-pointer">
-              📄 Pricing_Proposal_v2.pdf
+            <div className="text-sm text-slate-600 hover:text-slate-900 cursor-pointer flex items-center gap-1">
+              <FileText className="h-3 w-3" />
+              Pricing_Proposal_v2.pdf
             </div>
-            <div className="text-sm text-slate-600 hover:text-slate-900 cursor-pointer">
-              📊 ROI_Calculator.xlsx
+            <div className="text-sm text-slate-600 hover:text-slate-900 cursor-pointer flex items-center gap-1">
+              <BarChart2 className="h-3 w-3" />
+              ROI_Calculator.xlsx
             </div>
-            <div className="text-sm text-slate-600 hover:text-slate-900 cursor-pointer">
-              🎥 Product_Demo.mp4
+            <div className="text-sm text-slate-600 hover:text-slate-900 cursor-pointer flex items-center gap-1">
+              <Video className="h-3 w-3" />
+              Product_Demo.mp4
             </div>
             <Button variant="outline" size="sm" className="w-full mt-2">
               Upload New File
@@ -254,14 +261,17 @@ const LeadWorkspaceRight: React.FC<LeadWorkspaceRightProps> = ({
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              <p className="text-xs text-slate-600">
-                🎯 Your email response rate is 23% higher when including industry stats
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Target className="h-3 w-3" />
+                Your email response rate is 23% higher when including industry stats
               </p>
-              <p className="text-xs text-slate-600">
-                📞 Best call success: Tuesday-Thursday, 2-4 PM
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <PhoneCall className="h-3 w-3" />
+                Best call success: Tuesday-Thursday, 2-4 PM
               </p>
-              <p className="text-xs text-slate-600">
-                💡 Similar leads from {lead.source} respond well to case studies
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Lightbulb className="h-3 w-3" />
+                Similar leads from {lead.source} respond well to case studies
               </p>
             </div>
           </CardContent>

--- a/src/components/LeadWorkspace/tabs/LeadCallTab.tsx
+++ b/src/components/LeadWorkspace/tabs/LeadCallTab.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Textarea } from '@/components/ui/textarea';
-import { Phone, PhoneCall, Clock, Mic, MicOff, Brain, Save, Zap } from 'lucide-react';
+import { Phone, PhoneCall, Clock, Mic, MicOff, Brain, Save, Zap, Target } from 'lucide-react';
 import { Lead } from '@/types/lead';
 import { toast } from 'sonner';
 import { useIntegrations } from '@/hooks/useIntegrations';
@@ -320,14 +320,17 @@ Probability: 85% likely to move forward`;
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
-            <p className="text-xs text-slate-600">
-              📞 Your call conversion rate: 67% (above team average of 52%)
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <PhoneCall className="h-3 w-3" />
+              Your call conversion rate: 67% (above team average of 52%)
             </p>
-            <p className="text-xs text-slate-600">
-              ⏰ Optimal call length for this lead type: 15-20 minutes
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              Optimal call length for this lead type: 15-20 minutes
             </p>
-            <p className="text-xs text-slate-600">
-              🎯 Key phrases that resonate: "ROI", "time savings", "Q1 implementation"
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Target className="h-3 w-3" />
+              Key phrases that resonate: "ROI", "time savings", "Q1 implementation"
             </p>
           </div>
         </CardContent>

--- a/src/components/LeadWorkspace/tabs/LeadEmailTab.tsx
+++ b/src/components/LeadWorkspace/tabs/LeadEmailTab.tsx
@@ -4,7 +4,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { Brain, Send, Mail, Paperclip, Settings, Link } from 'lucide-react';
+import { Brain, Send, Mail, Paperclip, Settings, Link, Target, TrendingUp, Lightbulb } from 'lucide-react';
 import { Lead } from '@/types/lead';
 import { toast } from 'sonner';
 import { useIntegrations } from '@/hooks/useIntegrations';
@@ -247,14 +247,17 @@ P.S. Similar manufacturing companies typically see ROI within 3-4 months of impl
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              <p className="text-xs text-slate-600">
-                🎯 Response rate increases 34% when mentioning specific ROI numbers
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Target className="h-3 w-3" />
+                Response rate increases 34% when mentioning specific ROI numbers
               </p>
-              <p className="text-xs text-slate-600">
-                📈 Best send time for {lead.company}: Tuesday-Thursday, 10 AM - 2 PM
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <TrendingUp className="h-3 w-3" />
+                Best send time for {lead.company}: Tuesday-Thursday, 10 AM - 2 PM
               </p>
-              <p className="text-xs text-slate-600">
-                💡 Manufacturing companies respond well to concrete time savings examples
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Lightbulb className="h-3 w-3" />
+                Manufacturing companies respond well to concrete time savings examples
               </p>
             </div>
           </CardContent>

--- a/src/components/LeadWorkspace/tabs/LeadMeetingsTab.tsx
+++ b/src/components/LeadWorkspace/tabs/LeadMeetingsTab.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
-import { Calendar, Clock, Video, Users, MapPin, Brain, Plus, Link } from 'lucide-react';
+import { Calendar, Clock, Video, Users, MapPin, Brain, Plus, Link, Target, Lightbulb, PhoneCall, Building2 } from 'lucide-react';
 import { Lead } from '@/types/lead';
 import { toast } from 'sonner';
 import { useIntegrations } from '@/hooks/useIntegrations';
@@ -107,8 +107,8 @@ const LeadMeetingsTab: React.FC<LeadMeetingsTabProps> = ({ lead }) => {
   const getMeetingIcon = (type: string) => {
     switch (type) {
       case 'video': return <Video className="h-4 w-4 text-blue-600" />;
-      case 'phone': return <Clock className="h-4 w-4 text-green-600" />;
-      case 'in-person': return <MapPin className="h-4 w-4 text-purple-600" />;
+      case 'phone': return <PhoneCall className="h-4 w-4 text-green-600" />;
+      case 'in-person': return <Building2 className="h-4 w-4 text-purple-600" />;
       default: return <Calendar className="h-4 w-4 text-gray-600" />;
     }
   };
@@ -176,9 +176,15 @@ const LeadMeetingsTab: React.FC<LeadMeetingsTabProps> = ({ lead }) => {
                 <SelectValue placeholder="Meeting type" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="video">🎥 Google Meet</SelectItem>
-                <SelectItem value="phone">📞 Phone Call</SelectItem>
-                <SelectItem value="in-person">🏢 In Person</SelectItem>
+                <SelectItem value="video" className="flex items-center gap-1">
+                  <Video className="h-3 w-3" /> Google Meet
+                </SelectItem>
+                <SelectItem value="phone" className="flex items-center gap-1">
+                  <PhoneCall className="h-3 w-3" /> Phone Call
+                </SelectItem>
+                <SelectItem value="in-person" className="flex items-center gap-1">
+                  <Building2 className="h-3 w-3" /> In Person
+                </SelectItem>
               </SelectContent>
             </Select>
 
@@ -278,14 +284,17 @@ const LeadMeetingsTab: React.FC<LeadMeetingsTabProps> = ({ lead }) => {
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
-            <p className="text-xs text-slate-600">
-              📅 Your meeting show-up rate: 87% (above team average)
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Calendar className="h-3 w-3" />
+              Your meeting show-up rate: 87% (above team average)
             </p>
-            <p className="text-xs text-slate-600">
-              🎯 Best meeting length for demos: 30-45 minutes
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Target className="h-3 w-3" />
+              Best meeting length for demos: 30-45 minutes
             </p>
-            <p className="text-xs text-slate-600">
-              💡 Send calendar invite 24-48 hours in advance for best attendance
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Lightbulb className="h-3 w-3" />
+              Send calendar invite 24-48 hours in advance for best attendance
             </p>
           </div>
         </CardContent>

--- a/src/components/LeadWorkspace/tabs/LeadNotesTab.tsx
+++ b/src/components/LeadWorkspace/tabs/LeadNotesTab.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Brain, Save, Plus, Phone } from 'lucide-react';
+import { Brain, Save, Plus, Phone, Target, TrendingUp, Clock } from 'lucide-react';
 import { Lead } from '@/types/lead';
 import { toast } from 'sonner';
 import UnifiedAIAssistant from '../../UnifiedAI/UnifiedAIAssistant';
@@ -144,14 +144,17 @@ const LeadNotesTab: React.FC<LeadNotesTabProps> = ({ lead }) => {
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
-            <p className="text-xs text-slate-600">
-              🎯 Key themes: Budget approved, Q1 timeline, manual process pain
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Target className="h-3 w-3" />
+              Key themes: Budget approved, Q1 timeline, manual process pain
             </p>
-            <p className="text-xs text-slate-600">
-              📈 Sentiment trend: Positive → Very positive (improving)
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <TrendingUp className="h-3 w-3" />
+              Sentiment trend: Positive → Very positive (improving)
             </p>
-            <p className="text-xs text-slate-600">
-              ⏰ Last substantive update: 2 days ago (follow-up recommended)
+            <p className="text-xs text-slate-600 flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              Last substantive update: 2 days ago (follow-up recommended)
             </p>
           </div>
         </CardContent>

--- a/src/components/LeadWorkspace/tabs/LeadSMSTab.tsx
+++ b/src/components/LeadWorkspace/tabs/LeadSMSTab.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { MessageSquare, Send, Brain, Settings } from 'lucide-react';
+import { MessageSquare, Send, Brain, Settings, Smartphone, Clock, Lightbulb } from 'lucide-react';
 import { Lead } from '@/types/lead';
 import { toast } from 'sonner';
 import { useIntegrations } from '@/hooks/useIntegrations';
@@ -51,7 +51,7 @@ const LeadSMSTab: React.FC<LeadSMSTabProps> = ({ lead }) => {
   const handleAiAssist = () => {
     setIsAiAssisting(true);
     setTimeout(() => {
-      const aiMessage = `Hi ${lead.name.split(' ')[0]}! Just sent over that ROI calculator showing $45K+ potential savings. Perfect timing for your Q1 planning. Quick 15-min call to walk through it? 📊`;
+      const aiMessage = `Hi ${lead.name.split(' ')[0]}! Just sent over that ROI calculator showing $45K+ potential savings. Perfect timing for your Q1 planning. Quick 15-min call to walk through it?`;
       setMessage(aiMessage);
       setIsAiAssisting(false);
       toast.success('AI has generated an optimized SMS based on your conversation');
@@ -197,14 +197,17 @@ const LeadSMSTab: React.FC<LeadSMSTabProps> = ({ lead }) => {
           </CardHeader>
           <CardContent>
             <div className="space-y-2">
-              <p className="text-xs text-slate-600">
-                📱 Your SMS response rate: 78% (keep messages under 160 chars)
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Smartphone className="h-3 w-3" />
+                Your SMS response rate: 78% (keep messages under 160 chars)
               </p>
-              <p className="text-xs text-slate-600">
-                ⏰ Best SMS time for this lead: Business hours 9 AM - 5 PM
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                Best SMS time for this lead: Business hours 9 AM - 5 PM
               </p>
-              <p className="text-xs text-slate-600">
-                💡 Use emojis sparingly - this lead prefers professional tone
+              <p className="text-xs text-slate-600 flex items-center gap-1">
+                <Lightbulb className="h-3 w-3" />
+                Use emojis sparingly - this lead prefers professional tone
               </p>
             </div>
           </CardContent>

--- a/src/components/QuickStats.tsx
+++ b/src/components/QuickStats.tsx
@@ -1,53 +1,54 @@
 
 import React from 'react';
 import StatsCard from './StatsCard';
+import { PhoneCall, Target, Calendar, Timer } from 'lucide-react';
 
 const QuickStats = () => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       <div className="futuristic-card group hover:scale-105 transition-all duration-300">
-        <StatsCard 
-          title="Today's Calls" 
-          value={42} 
-          change="+15% vs. yesterday" 
-          changeType="increase" 
-          icon="📞"
+        <StatsCard
+          title="Today's Calls"
+          value={42}
+          change="+15% vs. yesterday"
+          changeType="increase"
+          icon={<PhoneCall className="h-4 w-4" />}
           tooltip="Call volume is a leading indicator of your conversion success. Aim for 50+ daily calls for optimal results."
           chartData={[15, 22, 28, 32, 38, 42]}
           color="yellow"
         />
       </div>
       <div className="futuristic-card group hover:scale-105 transition-all duration-300">
-        <StatsCard 
-          title="Leads Converted" 
-          value={7} 
-          change="+3 from yesterday" 
-          changeType="increase" 
-          icon="🎯"
+        <StatsCard
+          title="Leads Converted"
+          value={7}
+          change="+3 from yesterday"
+          changeType="increase"
+          icon={<Target className="h-4 w-4" />}
           tooltip="You're converting 16.7% of your calls today - well above the team average of 12%!"
           chartData={[2, 3, 4, 5, 6, 7]}
           color="green"
         />
       </div>
       <div className="futuristic-card group hover:scale-105 transition-all duration-300">
-        <StatsCard 
-          title="Meetings Scheduled" 
-          value={4} 
-          change="Same as yesterday" 
-          changeType="neutral" 
-          icon="🗓️"
+        <StatsCard
+          title="Meetings Scheduled"
+          value={4}
+          change="Same as yesterday"
+          changeType="neutral"
+          icon={<Calendar className="h-4 w-4" />}
           tooltip="Consistent meeting scheduling leads to more predictable revenue. You need 2 more today to hit your goal."
           chartData={[3, 5, 2, 6, 4, 4]}
           color="blue"
         />
       </div>
       <div className="futuristic-card group hover:scale-105 transition-all duration-300">
-        <StatsCard 
-          title="Response Time" 
-          value="3:42" 
-          change="-12% vs. yesterday" 
-          changeType="increase" 
-          icon="⏱️"
+        <StatsCard
+          title="Response Time"
+          value="3:42"
+          change="-12% vs. yesterday"
+          changeType="increase"
+          icon={<Timer className="h-4 w-4" />}
           tooltip="Faster response times correlate with 28% higher conversion rates. You're trending in the right direction!"
           chartData={[5.2, 4.8, 4.5, 4.1, 3.9, 3.7]}
           color="purple"

--- a/src/components/StatsCard.tsx
+++ b/src/components/StatsCard.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { Card } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info, TrendingUp, TrendingDown, Minus } from "lucide-react";
@@ -11,7 +11,7 @@ interface StatsCardProps {
   value: string | number;
   change?: string;
   changeType?: 'increase' | 'decrease' | 'neutral';
-  icon?: string;
+  icon?: ReactNode;
   tooltip?: string;
   chartData?: number[];
   color?: ColorVariant;
@@ -24,7 +24,8 @@ const StatsCard = ({
   changeType = 'neutral',
   tooltip,
   chartData = [],
-  color = 'default'
+  color = 'default',
+  icon
 }: StatsCardProps) => {
   const changeColorClass = 
     changeType === 'increase' ? 'text-emerald-600' : 
@@ -66,6 +67,9 @@ const StatsCard = ({
             </div>
           )}
         </div>
+        {icon && (
+          <div className="ml-3 text-slate-500 flex-shrink-0">{icon}</div>
+        )}
       </div>
       
       {/* Micro Chart */}


### PR DESCRIPTION
## Summary
- allow `StatsCard` to accept React node icons
- swap emoji icons for lucide-react icons in QuickStats
- update LeadWorkspace tabs to use lucide icons
- clean up AI SMS message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842f5ed52a48328b44d46df68b40991