### PR TITLE
Add mobile navigation to OS layouts

### DIFF
--- a/src/layouts/DeveloperLayout.tsx
+++ b/src/layouts/DeveloperLayout.tsx
@@ -1,7 +1,22 @@
 
-import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import DeveloperNavigation from '@/components/Navigation/DeveloperNavigation';
+import MobileNavigation from '@/components/Navigation/MobileNavigation';
+import { updateActiveItem } from '@/components/Navigation/navigationUtils';
+import type { NavItem } from '@/components/Navigation/navigationConfig';
+import {
+  Monitor,
+  Brain,
+  Activity,
+  Code,
+  AlertTriangle,
+  Database,
+  CheckSquare,
+  TestTube,
+  GitBranch,
+  Settings,
+} from 'lucide-react';
 
 // Developer pages
 import DeveloperDashboard from '@/pages/developer/Dashboard';
@@ -17,11 +32,31 @@ import DeveloperCRMIntegrations from '@/pages/developer/CRMIntegrations';
 
 import UnifiedAIBubble from '@/components/UnifiedAI/UnifiedAIBubble';
 import { useAIContext } from '@/contexts/AIContext';
-import { useLocation } from 'react-router-dom';
 
 const DeveloperLayout = () => {
   const { currentLead, isCallActive, emailContext, smsContext } = useAIContext();
   const location = useLocation();
+  const [activeItem, setActiveItem] = useState('dashboard');
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    updateActiveItem(location.pathname, setActiveItem);
+  }, [location]);
+
+  const navItems: NavItem[] = [
+    { icon: <Monitor className="h-5 w-5" />, label: 'Dashboard', href: '/developer/dashboard' },
+    { icon: <Brain className="h-5 w-5" />, label: 'AI Brain Hub', href: '/developer/ai-brain-logs' },
+    { icon: <Activity className="h-5 w-5" />, label: 'System Monitor', href: '/developer/system-monitor' },
+    { icon: <Code className="h-5 w-5" />, label: 'API Logs', href: '/developer/api-logs' },
+    { icon: <AlertTriangle className="h-5 w-5" />, label: 'Error Logs', href: '/developer/error-logs' },
+    { icon: <Database className="h-5 w-5" />, label: 'CRM Integration Dashboard', href: '/developer/crm-integrations' },
+    { icon: <CheckSquare className="h-5 w-5" />, label: 'QA Checklist', href: '/developer/qa-checklist' },
+    { icon: <TestTube className="h-5 w-5" />, label: 'Testing Tools', href: '/developer/testing-sandbox' },
+    { icon: <GitBranch className="h-5 w-5" />, label: 'Version Control', href: '/developer/version-control' },
+    { icon: <Settings className="h-5 w-5" />, label: 'Settings', href: '/developer/settings' },
+  ];
+
+  const getDashboardUrl = () => '/developer/dashboard';
   
   const getWorkspaceContext = () => {
     const path = location.pathname;
@@ -46,11 +81,18 @@ const DeveloperLayout = () => {
     emailContext,
     smsContext
   };
-  
+
   return (
     <div className="min-h-screen bg-slate-900 text-white relative">
       <DeveloperNavigation />
-      
+      <MobileNavigation
+        navItems={navItems}
+        activeItem={activeItem}
+        mobileMenuOpen={mobileMenuOpen}
+        setMobileMenuOpen={setMobileMenuOpen}
+        getDashboardUrl={getDashboardUrl}
+      />
+
       <main className="pt-[60px]">
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />

--- a/src/layouts/ManagerLayout.tsx
+++ b/src/layouts/ManagerLayout.tsx
@@ -1,7 +1,19 @@
 
-import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
+import MobileNavigation from '@/components/Navigation/MobileNavigation';
+import { updateActiveItem } from '@/components/Navigation/navigationUtils';
+import type { NavItem } from '@/components/Navigation/navigationConfig';
+import {
+  BarChart3,
+  Users,
+  Database,
+  Brain,
+  Settings,
+  Shield,
+  FileText,
+} from 'lucide-react';
 
 // Manager pages
 import ManagerDashboard from '@/pages/manager/Dashboard';
@@ -17,11 +29,31 @@ import ManagerSettings from '@/pages/manager/Settings';
 
 import UnifiedAIBubble from '@/components/UnifiedAI/UnifiedAIBubble';
 import { useAIContext } from '@/contexts/AIContext';
-import { useLocation } from 'react-router-dom';
 
 const ManagerLayout = () => {
   const { currentLead, isCallActive, emailContext, smsContext } = useAIContext();
   const location = useLocation();
+  const [activeItem, setActiveItem] = useState('dashboard');
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    updateActiveItem(location.pathname, setActiveItem);
+  }, [location]);
+
+  const navItems: NavItem[] = [
+    { icon: <BarChart3 className="h-5 w-5" />, label: 'Dashboard', href: '/manager/dashboard' },
+    { icon: <BarChart3 className="h-5 w-5" />, label: 'Analytics', href: '/manager/analytics' },
+    { icon: <Users className="h-5 w-5" />, label: 'Lead Management', href: '/manager/lead-management' },
+    { icon: <Database className="h-5 w-5" />, label: 'Company Brain', href: '/manager/company-brain' },
+    { icon: <Brain className="h-5 w-5" />, label: 'AI Assistant', href: '/manager/ai' },
+    { icon: <Database className="h-5 w-5" />, label: 'CRM Integrations', href: '/manager/crm-integrations' },
+    { icon: <Users className="h-5 w-5" />, label: 'Team Management', href: '/manager/team-management' },
+    { icon: <Shield className="h-5 w-5" />, label: 'Security', href: '/manager/security' },
+    { icon: <FileText className="h-5 w-5" />, label: 'Reports', href: '/manager/reports' },
+    { icon: <Settings className="h-5 w-5" />, label: 'Settings', href: '/manager/settings' },
+  ];
+
+  const getDashboardUrl = () => '/manager/dashboard';
   
   const getWorkspaceContext = () => {
     const path = location.pathname;
@@ -46,11 +78,18 @@ const ManagerLayout = () => {
     emailContext,
     smsContext
   };
-  
+
   return (
     <div className="min-h-screen bg-slate-50 relative">
       <ManagerNavigation />
-      
+      <MobileNavigation
+        navItems={navItems}
+        activeItem={activeItem}
+        mobileMenuOpen={mobileMenuOpen}
+        setMobileMenuOpen={setMobileMenuOpen}
+        getDashboardUrl={getDashboardUrl}
+      />
+
       <main className="pt-[60px]">
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />

--- a/src/layouts/SalesLayout.tsx
+++ b/src/layouts/SalesLayout.tsx
@@ -1,7 +1,19 @@
 
-import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import SalesNavigation from '@/components/Navigation/SalesNavigation';
+import MobileNavigation from '@/components/Navigation/MobileNavigation';
+import { updateActiveItem } from '@/components/Navigation/navigationUtils';
+import type { NavItem } from '@/components/Navigation/navigationConfig';
+import {
+  Grid,
+  Users,
+  Bot,
+  Phone,
+  BarChart3,
+  GraduationCap,
+  Wrench,
+} from 'lucide-react';
 
 // Sales pages
 import SalesRepDashboard from '@/pages/sales/Dashboard';
@@ -15,11 +27,28 @@ import LeadWorkspace from '@/pages/LeadWorkspace';
 
 import UnifiedAIBubble from '@/components/UnifiedAI/UnifiedAIBubble';
 import { useAIContext } from '@/contexts/AIContext';
-import { useLocation } from 'react-router-dom';
 
 const SalesLayout = () => {
   const { currentLead, isCallActive, emailContext, smsContext } = useAIContext();
   const location = useLocation();
+  const [activeItem, setActiveItem] = useState('dashboard');
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    updateActiveItem(location.pathname, setActiveItem);
+  }, [location]);
+
+  const navItems: NavItem[] = [
+    { icon: <Grid className="h-5 w-5" />, label: 'Dashboard', href: '/sales/dashboard' },
+    { icon: <Users className="h-5 w-5" />, label: 'Lead Management', href: '/sales/lead-management' },
+    { icon: <Bot className="h-5 w-5" />, label: 'AI Agent', href: '/sales/ai' },
+    { icon: <Phone className="h-5 w-5" />, label: 'Dialer', href: '/sales/dialer' },
+    { icon: <BarChart3 className="h-5 w-5" />, label: 'Analytics', href: '/sales/analytics' },
+    { icon: <GraduationCap className="h-5 w-5" />, label: 'Academy', href: '/sales/academy' },
+    { icon: <Wrench className="h-5 w-5" />, label: 'Settings', href: '/sales/settings' },
+  ];
+
+  const getDashboardUrl = () => '/sales/dashboard';
   
   // Determine workspace context from current route
   const getWorkspaceContext = () => {
@@ -51,11 +80,18 @@ const SalesLayout = () => {
     emailContext,
     smsContext
   };
-  
+
   return (
     <div className="min-h-screen bg-slate-50 relative">
       <SalesNavigation />
-      
+      <MobileNavigation
+        navItems={navItems}
+        activeItem={activeItem}
+        mobileMenuOpen={mobileMenuOpen}
+        setMobileMenuOpen={setMobileMenuOpen}
+        getDashboardUrl={getDashboardUrl}
+      />
+
       <main className="pt-[60px]">
         <Routes>
           <Route path="/" element={<Navigate to="/dashboard" replace />} />


### PR DESCRIPTION
## Summary
- add `MobileNavigation` to `SalesLayout`, `ManagerLayout`, and `DeveloperLayout`
- supply OS specific nav items and toggle state for mobile menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842f9d7686c83288bdbdb5356d2f696