### PR TITLE
Unify navigation with role support

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,8 +6,12 @@ import DesktopNavigation from './Navigation/DesktopNavigation';
 import MobileNavigation from './Navigation/MobileNavigation';
 import { getDashboardUrl, updateActiveItem } from './Navigation/navigationUtils';
 import { createNavItems } from './Navigation/navigationConfig';
+import type { Role } from '@/contexts/auth/types';
+interface NavigationProps {
+  role?: Role;
+}
 
-const Navigation = () => {
+const Navigation: React.FC<NavigationProps> = ({ role }) => {
   const location = useLocation();
   const { profile } = useAuth();
   const [activeItem, setActiveItem] = useState('dashboard');
@@ -21,7 +25,9 @@ const Navigation = () => {
     updateActiveItem(location.pathname, setActiveItem);
   }, [location]);
   
-  const navItems = createNavItems(dashboardUrl);
+  const userRole = role || profile?.role || 'sales_rep';
+
+  const navItems = createNavItems(userRole, dashboardUrl);
   
   return (
     <div className="bg-sidebar text-sidebar-foreground shadow-lg">

--- a/src/components/Navigation/navigationConfig.tsx
+++ b/src/components/Navigation/navigationConfig.tsx
@@ -1,18 +1,26 @@
 
 import React from 'react';
-import { 
-  BarChart3, 
-  Users, 
-  Brain, 
-  Phone, 
-  Settings, 
+import {
+  BarChart3,
+  Users,
+  Brain,
+  Phone,
+  Settings,
   FileText,
   Grid,
-  TrendingUp,
   Bot,
-  Target,
-  GraduationCap
+  GraduationCap,
+  Monitor,
+  Activity,
+  Code,
+  AlertTriangle,
+  Database,
+  CheckSquare,
+  TestTube,
+  GitBranch,
+  Shield
 } from 'lucide-react';
+import type { Role } from '@/contexts/auth/types';
 
 export interface NavItem {
   icon: React.ReactNode;
@@ -22,66 +30,155 @@ export interface NavItem {
   description?: string;
 }
 
-export const createNavItems = (getDashboardUrl: () => string): NavItem[] => [
-  {
-    icon: <Grid className="h-5 w-5" />,
-    label: 'Dashboard',
-    href: getDashboardUrl(),
-    description: 'Overview and key metrics'
-  },
-  {
-    icon: <Users className="h-5 w-5" />,
-    label: 'Leads',
-    href: '/leads',
-    badge: '24',
-    description: 'Lead management and tracking'
-  },
-  {
-    icon: <Bot className="h-5 w-5" />,
-    label: 'AI Agent',
-    href: '/ai-agent',
-    description: 'AI-powered calling assistant'
-  },
-  {
-    icon: <Phone className="h-5 w-5" />,
-    label: 'Dialer',
-    href: '/dialer',
-    description: 'Auto-dialer and call management'
-  },
-  {
-    icon: <BarChart3 className="h-5 w-5" />,
-    label: 'Analytics',
-    href: '/analytics',
-    description: 'Performance insights and reports'
-  },
-  {
-    icon: <TrendingUp className="h-5 w-5" />,
-    label: 'Manager Analytics',
-    href: '/manager-analytics',
-    description: 'Executive command center'
-  },
-  {
-    icon: <Brain className="h-5 w-5" />,
-    label: 'Company Brain',
-    href: '/company-brain',
-    description: 'Knowledge base and AI insights'
-  },
-  {
-    icon: <GraduationCap className="h-5 w-5" />,
-    label: 'Academy',
-    href: '/academy',
-    description: 'Training and learning resources'
-  },
-  {
-    icon: <FileText className="h-5 w-5" />,
-    label: 'Reports',
-    href: '/reports',
-    description: 'Detailed reports and analytics'
-  },
-  {
-    icon: <Settings className="h-5 w-5" />,
-    label: 'Settings',
-    href: '/settings',
-    description: 'Account and system settings'
+export const createNavItems = (
+  role: Role,
+  getDashboardUrl: () => string
+): NavItem[] => {
+  switch (role) {
+    case 'manager':
+      return [
+        {
+          icon: <BarChart3 className="h-5 w-5" />,
+          label: 'Dashboard',
+          href: '/manager/dashboard'
+        },
+        {
+          icon: <BarChart3 className="h-5 w-5" />,
+          label: 'Analytics',
+          href: '/manager/analytics'
+        },
+        {
+          icon: <Users className="h-5 w-5" />,
+          label: 'Lead Management',
+          href: '/manager/lead-management'
+        },
+        {
+          icon: <Database className="h-5 w-5" />,
+          label: 'Company Brain',
+          href: '/manager/company-brain'
+        },
+        {
+          icon: <Brain className="h-5 w-5" />,
+          label: 'AI Assistant',
+          href: '/manager/ai'
+        },
+        {
+          icon: <Database className="h-5 w-5" />,
+          label: 'CRM Integrations',
+          href: '/manager/crm-integrations'
+        },
+        {
+          icon: <Users className="h-5 w-5" />,
+          label: 'Team Management',
+          href: '/manager/team-management'
+        },
+        {
+          icon: <Shield className="h-5 w-5" />,
+          label: 'Security',
+          href: '/manager/security'
+        },
+        {
+          icon: <FileText className="h-5 w-5" />,
+          label: 'Reports',
+          href: '/manager/reports'
+        },
+        {
+          icon: <Settings className="h-5 w-5" />,
+          label: 'Settings',
+          href: '/manager/settings'
+        }
+      ];
+    case 'developer':
+      return [
+        {
+          icon: <Monitor className="h-5 w-5" />,
+          label: 'Dashboard',
+          href: '/developer/dashboard'
+        },
+        {
+          icon: <Brain className="h-5 w-5" />,
+          label: 'AI Brain Hub',
+          href: '/developer/ai-brain-logs'
+        },
+        {
+          icon: <Activity className="h-5 w-5" />,
+          label: 'System Monitor',
+          href: '/developer/system-monitor'
+        },
+        {
+          icon: <Code className="h-5 w-5" />,
+          label: 'API Logs',
+          href: '/developer/api-logs'
+        },
+        {
+          icon: <AlertTriangle className="h-5 w-5" />,
+          label: 'Error Logs',
+          href: '/developer/error-logs'
+        },
+        {
+          icon: <Database className="h-5 w-5" />,
+          label: 'CRM Integration Dashboard',
+          href: '/developer/crm-integrations'
+        },
+        {
+          icon: <CheckSquare className="h-5 w-5" />,
+          label: 'QA Checklist',
+          href: '/developer/qa-checklist'
+        },
+        {
+          icon: <TestTube className="h-5 w-5" />,
+          label: 'Testing Tools',
+          href: '/developer/testing-sandbox'
+        },
+        {
+          icon: <GitBranch className="h-5 w-5" />,
+          label: 'Version Control',
+          href: '/developer/version-control'
+        },
+        {
+          icon: <Settings className="h-5 w-5" />,
+          label: 'Settings',
+          href: '/developer/settings'
+        }
+      ];
+    case 'sales_rep':
+    default:
+      return [
+        {
+          icon: <Grid className="h-5 w-5" />,
+          label: 'Dashboard',
+          href: getDashboardUrl()
+        },
+        {
+          icon: <Users className="h-5 w-5" />,
+          label: 'Lead Management',
+          href: '/sales/lead-management'
+        },
+        {
+          icon: <Bot className="h-5 w-5" />,
+          label: 'AI Agent',
+          href: '/sales/ai'
+        },
+        {
+          icon: <Phone className="h-5 w-5" />,
+          label: 'Dialer',
+          href: '/sales/dialer'
+        },
+        {
+          icon: <BarChart3 className="h-5 w-5" />,
+          label: 'Analytics',
+          href: '/sales/analytics'
+        },
+        {
+          icon: <GraduationCap className="h-5 w-5" />,
+          label: 'Academy',
+          href: '/sales/academy'
+        },
+        {
+          icon: <Settings className="h-5 w-5" />,
+          label: 'Settings',
+          href: '/sales/settings'
+        }
+      ];
   }
-];
+};

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { cn } from '@/lib/utils';
-import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
+import Navigation from '@/components/Navigation';
 
 interface SidebarProps {
   className?: string;
@@ -13,7 +13,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ className }) => {
       "w-64 bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 flex flex-col",
       className
     )}>
-      <ManagerNavigation />
+      <Navigation role="manager" />
     </div>
   );
 };

--- a/src/layouts/DeveloperLayout.tsx
+++ b/src/layouts/DeveloperLayout.tsx
@@ -1,22 +1,7 @@
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import DeveloperNavigation from '@/components/Navigation/DeveloperNavigation';
-import MobileNavigation from '@/components/Navigation/MobileNavigation';
-import { updateActiveItem } from '@/components/Navigation/navigationUtils';
-import type { NavItem } from '@/components/Navigation/navigationConfig';
-import {
-  Monitor,
-  Brain,
-  Activity,
-  Code,
-  AlertTriangle,
-  Database,
-  CheckSquare,
-  TestTube,
-  GitBranch,
-  Settings,
-} from 'lucide-react';
+import Navigation from '@/components/Navigation';
 
 // Developer pages
 import DeveloperDashboard from '@/pages/developer/Dashboard';
@@ -36,27 +21,6 @@ import { useAIContext } from '@/contexts/AIContext';
 const DeveloperLayout = () => {
   const { currentLead, isCallActive, emailContext, smsContext } = useAIContext();
   const location = useLocation();
-  const [activeItem, setActiveItem] = useState('dashboard');
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  useEffect(() => {
-    updateActiveItem(location.pathname, setActiveItem);
-  }, [location]);
-
-  const navItems: NavItem[] = [
-    { icon: <Monitor className="h-5 w-5" />, label: 'Dashboard', href: '/developer/dashboard' },
-    { icon: <Brain className="h-5 w-5" />, label: 'AI Brain Hub', href: '/developer/ai-brain-logs' },
-    { icon: <Activity className="h-5 w-5" />, label: 'System Monitor', href: '/developer/system-monitor' },
-    { icon: <Code className="h-5 w-5" />, label: 'API Logs', href: '/developer/api-logs' },
-    { icon: <AlertTriangle className="h-5 w-5" />, label: 'Error Logs', href: '/developer/error-logs' },
-    { icon: <Database className="h-5 w-5" />, label: 'CRM Integration Dashboard', href: '/developer/crm-integrations' },
-    { icon: <CheckSquare className="h-5 w-5" />, label: 'QA Checklist', href: '/developer/qa-checklist' },
-    { icon: <TestTube className="h-5 w-5" />, label: 'Testing Tools', href: '/developer/testing-sandbox' },
-    { icon: <GitBranch className="h-5 w-5" />, label: 'Version Control', href: '/developer/version-control' },
-    { icon: <Settings className="h-5 w-5" />, label: 'Settings', href: '/developer/settings' },
-  ];
-
-  const getDashboardUrl = () => '/developer/dashboard';
   
   const getWorkspaceContext = () => {
     const path = location.pathname;
@@ -83,36 +47,30 @@ const DeveloperLayout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-900 text-white relative">
-      <DeveloperNavigation />
-      <MobileNavigation
-        navItems={navItems}
-        activeItem={activeItem}
-        mobileMenuOpen={mobileMenuOpen}
-        setMobileMenuOpen={setMobileMenuOpen}
-        getDashboardUrl={getDashboardUrl}
-      />
+    <div className="min-h-screen bg-slate-900 text-white relative flex">
+      <Navigation role="developer" />
+      <div className="flex-1 lg:pl-64">
+        <main>
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<DeveloperDashboard />} />
+            <Route path="/system-monitor" element={<DeveloperSystemMonitor />} />
+            <Route path="/ai-brain-logs" element={<DeveloperAILogs />} />
+            <Route path="/api-logs" element={<DeveloperAPILogs />} />
+            <Route path="/error-logs" element={<DeveloperErrorLogs />} />
+            <Route path="/qa-checklist" element={<DeveloperQAChecklist />} />
+            <Route path="/testing-sandbox" element={<DeveloperTestingSandbox />} />
+            <Route path="/version-control" element={<DeveloperVersionControl />} />
+            <Route path="/crm-integrations" element={<DeveloperCRMIntegrations />} />
+            <Route path="/settings" element={<DeveloperSettings />} />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </main>
 
-      <main className="pt-[60px]">
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<DeveloperDashboard />} />
-          <Route path="/system-monitor" element={<DeveloperSystemMonitor />} />
-          <Route path="/ai-brain-logs" element={<DeveloperAILogs />} />
-          <Route path="/api-logs" element={<DeveloperAPILogs />} />
-          <Route path="/error-logs" element={<DeveloperErrorLogs />} />
-          <Route path="/qa-checklist" element={<DeveloperQAChecklist />} />
-          <Route path="/testing-sandbox" element={<DeveloperTestingSandbox />} />
-          <Route path="/version-control" element={<DeveloperVersionControl />} />
-          <Route path="/crm-integrations" element={<DeveloperCRMIntegrations />} />
-          <Route path="/settings" element={<DeveloperSettings />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Routes>
-      </main>
-      
-      {/* Developer AI Assistant */}
-      <div className="fixed bottom-6 right-6 z-[9999]">
-        <UnifiedAIBubble context={aiContext} />
+        {/* Developer AI Assistant */}
+        <div className="fixed bottom-6 right-6 z-[9999]">
+          <UnifiedAIBubble context={aiContext} />
+        </div>
       </div>
     </div>
   );

--- a/src/layouts/DeveloperOS.tsx
+++ b/src/layouts/DeveloperOS.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import DeveloperNavigation from '@/components/Navigation/DeveloperNavigation';
+import Navigation from '@/components/Navigation';
 
 // Developer Pages
 import DeveloperDashboard from '@/pages/developer/Dashboard';
@@ -18,7 +18,7 @@ import DeveloperCRMIntegrations from '@/pages/developer/CRMIntegrations';
 const DeveloperOS: React.FC = () => {
   return (
     <div className="min-h-screen bg-slate-900 text-white">
-      <DeveloperNavigation />
+      <Navigation role="developer" />
       <main className="pt-16">
         <Routes>
           <Route index element={<DeveloperDashboard />} />

--- a/src/layouts/ManagerLayout.tsx
+++ b/src/layouts/ManagerLayout.tsx
@@ -1,19 +1,7 @@
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
-import MobileNavigation from '@/components/Navigation/MobileNavigation';
-import { updateActiveItem } from '@/components/Navigation/navigationUtils';
-import type { NavItem } from '@/components/Navigation/navigationConfig';
-import {
-  BarChart3,
-  Users,
-  Database,
-  Brain,
-  Settings,
-  Shield,
-  FileText,
-} from 'lucide-react';
+import Navigation from '@/components/Navigation';
 
 // Manager pages
 import ManagerDashboard from '@/pages/manager/Dashboard';
@@ -33,27 +21,6 @@ import { useAIContext } from '@/contexts/AIContext';
 const ManagerLayout = () => {
   const { currentLead, isCallActive, emailContext, smsContext } = useAIContext();
   const location = useLocation();
-  const [activeItem, setActiveItem] = useState('dashboard');
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  useEffect(() => {
-    updateActiveItem(location.pathname, setActiveItem);
-  }, [location]);
-
-  const navItems: NavItem[] = [
-    { icon: <BarChart3 className="h-5 w-5" />, label: 'Dashboard', href: '/manager/dashboard' },
-    { icon: <BarChart3 className="h-5 w-5" />, label: 'Analytics', href: '/manager/analytics' },
-    { icon: <Users className="h-5 w-5" />, label: 'Lead Management', href: '/manager/lead-management' },
-    { icon: <Database className="h-5 w-5" />, label: 'Company Brain', href: '/manager/company-brain' },
-    { icon: <Brain className="h-5 w-5" />, label: 'AI Assistant', href: '/manager/ai' },
-    { icon: <Database className="h-5 w-5" />, label: 'CRM Integrations', href: '/manager/crm-integrations' },
-    { icon: <Users className="h-5 w-5" />, label: 'Team Management', href: '/manager/team-management' },
-    { icon: <Shield className="h-5 w-5" />, label: 'Security', href: '/manager/security' },
-    { icon: <FileText className="h-5 w-5" />, label: 'Reports', href: '/manager/reports' },
-    { icon: <Settings className="h-5 w-5" />, label: 'Settings', href: '/manager/settings' },
-  ];
-
-  const getDashboardUrl = () => '/manager/dashboard';
   
   const getWorkspaceContext = () => {
     const path = location.pathname;
@@ -80,36 +47,30 @@ const ManagerLayout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 relative">
-      <ManagerNavigation />
-      <MobileNavigation
-        navItems={navItems}
-        activeItem={activeItem}
-        mobileMenuOpen={mobileMenuOpen}
-        setMobileMenuOpen={setMobileMenuOpen}
-        getDashboardUrl={getDashboardUrl}
-      />
+    <div className="min-h-screen bg-slate-50 relative flex">
+      <Navigation role="manager" />
+      <div className="flex-1 lg:pl-64">
+        <main>
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<ManagerDashboard />} />
+            <Route path="/analytics" element={<ManagerAnalytics />} />
+            <Route path="/lead-management" element={<ManagerLeadManagement />} />
+            <Route path="/company-brain" element={<ManagerCompanyBrain />} />
+            <Route path="/ai" element={<ManagerAI />} />
+            <Route path="/crm-integrations" element={<ManagerCRMIntegrations />} />
+            <Route path="/team-management" element={<TeamManagement />} />
+            <Route path="/security" element={<SecurityPage />} />
+            <Route path="/reports" element={<Reports />} />
+            <Route path="/settings" element={<ManagerSettings />} />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </main>
 
-      <main className="pt-[60px]">
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<ManagerDashboard />} />
-          <Route path="/analytics" element={<ManagerAnalytics />} />
-          <Route path="/lead-management" element={<ManagerLeadManagement />} />
-          <Route path="/company-brain" element={<ManagerCompanyBrain />} />
-          <Route path="/ai" element={<ManagerAI />} />
-          <Route path="/crm-integrations" element={<ManagerCRMIntegrations />} />
-          <Route path="/team-management" element={<TeamManagement />} />
-          <Route path="/security" element={<SecurityPage />} />
-          <Route path="/reports" element={<Reports />} />
-          <Route path="/settings" element={<ManagerSettings />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Routes>
-      </main>
-      
-      {/* Manager AI Assistant */}
-      <div className="fixed bottom-6 right-6 z-[9999]">
-        <UnifiedAIBubble context={aiContext} />
+        {/* Manager AI Assistant */}
+        <div className="fixed bottom-6 right-6 z-[9999]">
+          <UnifiedAIBubble context={aiContext} />
+        </div>
       </div>
     </div>
   );

--- a/src/layouts/ManagerOS.tsx
+++ b/src/layouts/ManagerOS.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
+import Navigation from '@/components/Navigation';
 
 // Manager Pages
 import ManagerDashboard from '@/pages/manager/Dashboard';
@@ -14,7 +14,7 @@ import ManagerSettings from '@/pages/manager/Settings';
 const ManagerOS: React.FC = () => {
   return (
     <div className="min-h-screen bg-background">
-      <ManagerNavigation />
+      <Navigation role="manager" />
       <main className="pt-16">
         <Routes>
           <Route index element={<ManagerDashboard />} />

--- a/src/layouts/SalesLayout.tsx
+++ b/src/layouts/SalesLayout.tsx
@@ -1,19 +1,7 @@
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import SalesNavigation from '@/components/Navigation/SalesNavigation';
-import MobileNavigation from '@/components/Navigation/MobileNavigation';
-import { updateActiveItem } from '@/components/Navigation/navigationUtils';
-import type { NavItem } from '@/components/Navigation/navigationConfig';
-import {
-  Grid,
-  Users,
-  Bot,
-  Phone,
-  BarChart3,
-  GraduationCap,
-  Wrench,
-} from 'lucide-react';
+import Navigation from '@/components/Navigation';
 
 // Sales pages
 import SalesRepDashboard from '@/pages/sales/Dashboard';
@@ -31,24 +19,6 @@ import { useAIContext } from '@/contexts/AIContext';
 const SalesLayout = () => {
   const { currentLead, isCallActive, emailContext, smsContext } = useAIContext();
   const location = useLocation();
-  const [activeItem, setActiveItem] = useState('dashboard');
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
-  useEffect(() => {
-    updateActiveItem(location.pathname, setActiveItem);
-  }, [location]);
-
-  const navItems: NavItem[] = [
-    { icon: <Grid className="h-5 w-5" />, label: 'Dashboard', href: '/sales/dashboard' },
-    { icon: <Users className="h-5 w-5" />, label: 'Lead Management', href: '/sales/lead-management' },
-    { icon: <Bot className="h-5 w-5" />, label: 'AI Agent', href: '/sales/ai' },
-    { icon: <Phone className="h-5 w-5" />, label: 'Dialer', href: '/sales/dialer' },
-    { icon: <BarChart3 className="h-5 w-5" />, label: 'Analytics', href: '/sales/analytics' },
-    { icon: <GraduationCap className="h-5 w-5" />, label: 'Academy', href: '/sales/academy' },
-    { icon: <Wrench className="h-5 w-5" />, label: 'Settings', href: '/sales/settings' },
-  ];
-
-  const getDashboardUrl = () => '/sales/dashboard';
   
   // Determine workspace context from current route
   const getWorkspaceContext = () => {
@@ -82,34 +52,28 @@ const SalesLayout = () => {
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 relative">
-      <SalesNavigation />
-      <MobileNavigation
-        navItems={navItems}
-        activeItem={activeItem}
-        mobileMenuOpen={mobileMenuOpen}
-        setMobileMenuOpen={setMobileMenuOpen}
-        getDashboardUrl={getDashboardUrl}
-      />
+    <div className="min-h-screen bg-slate-50 relative flex">
+      <Navigation role="sales_rep" />
+      <div className="flex-1 lg:pl-64">
+        <main>
+          <Routes>
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/dashboard" element={<SalesRepDashboard />} />
+            <Route path="/analytics" element={<SalesAnalytics />} />
+            <Route path="/lead-management" element={<SalesLeadManagement />} />
+            <Route path="/lead-workspace/:id" element={<LeadWorkspace />} />
+            <Route path="/dialer" element={<SalesDialer />} />
+            <Route path="/academy" element={<SalesAcademy />} />
+            <Route path="/ai" element={<SalesAI />} />
+            <Route path="/settings" element={<SalesSettings />} />
+            <Route path="*" element={<Navigate to="/dashboard" replace />} />
+          </Routes>
+        </main>
 
-      <main className="pt-[60px]">
-        <Routes>
-          <Route path="/" element={<Navigate to="/dashboard" replace />} />
-          <Route path="/dashboard" element={<SalesRepDashboard />} />
-          <Route path="/analytics" element={<SalesAnalytics />} />
-          <Route path="/lead-management" element={<SalesLeadManagement />} />
-          <Route path="/lead-workspace/:id" element={<LeadWorkspace />} />
-          <Route path="/dialer" element={<SalesDialer />} />
-          <Route path="/academy" element={<SalesAcademy />} />
-          <Route path="/ai" element={<SalesAI />} />
-          <Route path="/settings" element={<SalesSettings />} />
-          <Route path="*" element={<Navigate to="/dashboard" replace />} />
-        </Routes>
-      </main>
-      
-      {/* Unified AI Bubble - Single AI assistant with fixed positioning */}
-      <div className="fixed bottom-6 right-6 z-[9999]">
-        <UnifiedAIBubble context={aiContext} />
+        {/* Unified AI Bubble - Single AI assistant with fixed positioning */}
+        <div className="fixed bottom-6 right-6 z-[9999]">
+          <UnifiedAIBubble context={aiContext} />
+        </div>
       </div>
     </div>
   );

--- a/src/layouts/SalesRepOS.tsx
+++ b/src/layouts/SalesRepOS.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
-import SalesRepNavigation from '@/components/Navigation/SalesRepNavigation';
+import Navigation from '@/components/Navigation';
 
 // Sales Rep Pages
 import SalesRepDashboard from '@/pages/sales/Dashboard';
@@ -14,7 +14,7 @@ import SalesRepSettings from '@/pages/sales/Settings';
 const SalesRepOS: React.FC = () => {
   return (
     <div className="min-h-screen bg-background">
-      <SalesRepNavigation />
+      <Navigation role="sales_rep" />
       <main className="pt-16">
         <Routes>
           <Route index element={<SalesRepDashboard />} />

--- a/src/pages/ManagerDashboard.tsx
+++ b/src/pages/ManagerDashboard.tsx
@@ -10,7 +10,7 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
-import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
+import Navigation from '@/components/Navigation';
 import ManagerOverviewCards from '@/components/Manager/ManagerOverviewCards';
 import ManagerTeamTable from '@/components/Manager/ManagerTeamTable';
 import ManagerAIAssistant from '@/components/ManagerAI/ManagerAIAssistant';
@@ -222,7 +222,7 @@ const ManagerDashboard = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <ManagerNavigation />
+      <Navigation role="manager" />
       
       <main className="pt-[60px]">
         <div className="flex-1 px-4 md:px-6 py-6">

--- a/src/pages/manager/ManagerDashboard.tsx
+++ b/src/pages/manager/ManagerDashboard.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { useDemoData } from '@/contexts/DemoDataContext';
-import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
+import Navigation from '@/components/Navigation';
 import ManagerOverviewCards from '@/components/Manager/ManagerOverviewCards';
 import ManagerTeamTable from '@/components/Manager/ManagerTeamTable';
 import ManagerAIAssistant from '@/components/ManagerAI/ManagerAIAssistant';
@@ -108,7 +108,7 @@ const ManagerDashboard = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <ManagerNavigation />
+      <Navigation role="manager" />
       
       <main className="pt-[60px]">
         <div className="flex-1 px-4 md:px-6 py-6">


### PR DESCRIPTION
## Summary
- generate sidebar nav items from role
- accept a role prop in `Navigation`
- use new role-based navigation in layouts and OS pages
- replace all direct references to old role navigation components

## Testing
- `npm run lint`
- `npm test` *(runs vitest in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_6842ff2c2d488328ba78b6b08e7bff1f