### PR TITLE
Update ManagerOS padding

### DIFF
--- a/src/layouts/ManagerOS.tsx
+++ b/src/layouts/ManagerOS.tsx
@@ -15,7 +15,7 @@ const ManagerOS: React.FC = () => {
   return (
     <div className="min-h-screen bg-background">
       <ManagerNavigation />
-      <main className="pt-16">
+      <main className="pt-[60px]">
         <Routes>
           <Route index element={<ManagerDashboard />} />
           <Route path="dashboard" element={<ManagerDashboard />} />


### PR DESCRIPTION
## Summary
- adjust ManagerOS content padding to match ManagerNavigation height

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b548982c8328b8806e9df48c31bf