### PR TITLE
Update manager pages to design tokens

### DIFF
--- a/src/components/Manager/CompanyDashboard.tsx
+++ b/src/components/Manager/CompanyDashboard.tsx
@@ -246,8 +246,8 @@ const CompanyDashboard = () => {
               <div key={activity.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                 <div>
                   <p className="font-medium text-sm">{activity.rep}</p>
-                  <p className="text-xs text-gray-600">{activity.action}</p>
-                  <p className="text-xs text-gray-500">{activity.time}</p>
+                  <p className="text-xs text-muted-foreground">{activity.action}</p>
+                  <p className="text-xs text-muted-foreground">{activity.time}</p>
                 </div>
                 <Badge variant="secondary" className="bg-green-100 text-green-800">
                   {activity.value}

--- a/src/components/Manager/IntegrationsTab.tsx
+++ b/src/components/Manager/IntegrationsTab.tsx
@@ -123,7 +123,7 @@ const IntegrationsTab = () => {
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold">Social Media Integrations</h2>
-          <p className="text-gray-600">Connect your social media accounts to enhance AI insights and content analysis.</p>
+          <p className="text-muted-foreground">Connect your social media accounts to enhance AI insights and content analysis.</p>
         </div>
         <Button variant="outline" onClick={() => window.location.reload()}>
           <RefreshCw className="h-4 w-4 mr-2" />
@@ -155,10 +155,10 @@ const IntegrationsTab = () => {
               </CardHeader>
               
               <CardContent className="space-y-4">
-                <p className="text-sm text-gray-600">{integration.description}</p>
+                <p className="text-sm text-muted-foreground">{integration.description}</p>
                 
                 {integration.connected && integration.lastSync && (
-                  <div className="text-xs text-gray-500">
+                  <div className="text-xs text-muted-foreground">
                     Last synced: {new Date(integration.lastSync).toLocaleString()}
                   </div>
                 )}
@@ -208,7 +208,7 @@ const IntegrationsTab = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="space-y-2">
               <h4 className="font-semibold text-sm">Data Ingested:</h4>
-              <ul className="text-sm text-gray-600 space-y-1">
+              <ul className="text-sm text-muted-foreground space-y-1">
                 <li>• Posts, captions, and hashtags</li>
                 <li>• Comments and replies</li>
                 <li>• Engagement metrics (likes, shares, views)</li>
@@ -218,7 +218,7 @@ const IntegrationsTab = () => {
             </div>
             <div className="space-y-2">
               <h4 className="font-semibold text-sm">AI Enhancements:</h4>
-              <ul className="text-sm text-gray-600 space-y-1">
+              <ul className="text-sm text-muted-foreground space-y-1">
                 <li>• Content-aware lead responses</li>
                 <li>• Brand voice consistency</li>
                 <li>• Market trend analysis</li>

--- a/src/components/Manager/KnowledgeTab.tsx
+++ b/src/components/Manager/KnowledgeTab.tsx
@@ -14,7 +14,7 @@ const KnowledgeTab: React.FC = () => {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted-foreground">
             Add documents or URLs to build your company knowledge base.
           </p>
           <Button size="sm">Upload Content</Button>
@@ -29,7 +29,7 @@ const KnowledgeTab: React.FC = () => {
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted-foreground">
             Quickly search through all indexed material and refresh when needed.
           </p>
           <Button variant="outline" size="sm">

--- a/src/components/Manager/LeadAssignment.tsx
+++ b/src/components/Manager/LeadAssignment.tsx
@@ -13,7 +13,7 @@ const LeadAssignment: React.FC = () => {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm text-gray-600">Automatically distribute new leads to your team.</p>
+        <p className="text-sm text-muted-foreground">Automatically distribute new leads to your team.</p>
         <Button size="sm">
           Assign Leads
           <UserPlus className="h-4 w-4 ml-2" />

--- a/src/components/Manager/MarketingAnalytics.tsx
+++ b/src/components/Manager/MarketingAnalytics.tsx
@@ -13,7 +13,7 @@ const MarketingAnalytics: React.FC = () => {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-muted-foreground">
           View campaign performance and audience engagement metrics.
         </p>
         <Button variant="outline" size="sm">

--- a/src/pages/manager/AI.tsx
+++ b/src/pages/manager/AI.tsx
@@ -102,8 +102,8 @@ const ManagerAI = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">AI Assistant CEO</h1>
-          <p className="text-gray-600">Your strategic AI partner for management decisions</p>
+          <h1 className="text-3xl font-bold text-foreground">AI Assistant CEO</h1>
+          <p className="text-muted-foreground">Your strategic AI partner for management decisions</p>
         </div>
         <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
           <Brain className="h-3 w-3 mr-1" />
@@ -129,11 +129,11 @@ const ManagerAI = () => {
                     <div className={`max-w-[80%] p-3 rounded-lg ${
                       chat.type === 'user' 
                         ? 'bg-blue-600 text-white' 
-                        : 'bg-gray-100 text-gray-900'
+                        : 'bg-gray-100 text-foreground'
                     }`}>
                       <p className="text-sm whitespace-pre-line">{chat.message}</p>
                       <p className={`text-xs mt-1 ${
-                        chat.type === 'user' ? 'text-blue-100' : 'text-gray-500'
+                        chat.type === 'user' ? 'text-blue-100' : 'text-muted-foreground'
                       }`}>
                         {chat.time}
                       </p>
@@ -213,19 +213,19 @@ const ManagerAI = () => {
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Team Performance</span>
+                <span className="text-sm text-muted-foreground">Team Performance</span>
                 <Badge variant="default">115% of target</Badge>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Pipeline Health</span>
+                <span className="text-sm text-muted-foreground">Pipeline Health</span>
                 <Badge variant="secondary">Strong</Badge>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Deal Velocity</span>
+                <span className="text-sm text-muted-foreground">Deal Velocity</span>
                 <Badge variant="outline">18 days avg</Badge>
               </div>
               <div className="flex items-center justify-between">
-                <span className="text-sm text-gray-600">Win Rate</span>
+                <span className="text-sm text-muted-foreground">Win Rate</span>
                 <Badge variant="default">24.3%</Badge>
               </div>
             </CardContent>
@@ -250,10 +250,10 @@ const ManagerAI = () => {
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
                         <h4 className="font-medium text-sm">{insight.title}</h4>
-                        <p className="text-xs text-gray-600 mt-1">{insight.message}</p>
+                        <p className="text-xs text-muted-foreground mt-1">{insight.message}</p>
                         <div className="flex items-center gap-1 mt-2">
                           <Clock className="h-3 w-3 text-gray-400" />
-                          <span className="text-xs text-gray-500">{insight.time}</span>
+                          <span className="text-xs text-muted-foreground">{insight.time}</span>
                         </div>
                       </div>
                       <Badge 

--- a/src/pages/manager/Analytics.tsx
+++ b/src/pages/manager/Analytics.tsx
@@ -23,8 +23,8 @@ const ManagerAnalytics = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Manager Analytics</h1>
-          <p className="text-gray-600">Comprehensive team performance insights</p>
+          <h1 className="text-3xl font-bold text-foreground">Manager Analytics</h1>
+          <p className="text-muted-foreground">Comprehensive team performance insights</p>
         </div>
         <div className="flex items-center gap-3">
           <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
@@ -164,7 +164,7 @@ const ManagerAnalytics = () => {
                       </div>
                       <div>
                         <h4 className="font-medium">{rep.name}</h4>
-                        <p className="text-sm text-gray-600">{rep.deals} deals • {rep.value} pipeline</p>
+                        <p className="text-sm text-muted-foreground">{rep.deals} deals • {rep.value} pipeline</p>
                       </div>
                     </div>
                     <div className="flex items-center gap-4">
@@ -201,7 +201,7 @@ const ManagerAnalytics = () => {
                     <div key={index} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
                       <div>
                         <p className="font-medium text-sm">{source.source}</p>
-                        <p className="text-xs text-gray-600">{source.leads} leads • {source.conversion} conversion</p>
+                        <p className="text-xs text-muted-foreground">{source.leads} leads • {source.conversion} conversion</p>
                       </div>
                       <Badge variant="outline">{source.cost} CAC</Badge>
                     </div>
@@ -244,14 +244,14 @@ const ManagerAnalytics = () => {
                 <div className="grid grid-cols-5 gap-4 text-center">
                   <div className="p-4 border rounded-lg">
                     <div className="text-2xl font-bold text-blue-600">1,240</div>
-                    <p className="text-sm text-gray-600">Visitors</p>
+                    <p className="text-sm text-muted-foreground">Visitors</p>
                   </div>
                   <div className="flex items-center">
                     <div className="text-lg text-gray-400">→</div>
                   </div>
                   <div className="p-4 border rounded-lg">
                     <div className="text-2xl font-bold text-blue-600">186</div>
-                    <p className="text-sm text-gray-600">Demos Booked</p>
+                    <p className="text-sm text-muted-foreground">Demos Booked</p>
                     <p className="text-xs text-green-600">15% conversion</p>
                   </div>
                   <div className="flex items-center">
@@ -259,7 +259,7 @@ const ManagerAnalytics = () => {
                   </div>
                   <div className="p-4 border rounded-lg">
                     <div className="text-2xl font-bold text-blue-600">45</div>
-                    <p className="text-sm text-gray-600">Deals Closed</p>
+                    <p className="text-sm text-muted-foreground">Deals Closed</p>
                     <p className="text-xs text-green-600">24% close rate</p>
                   </div>
                 </div>

--- a/src/pages/manager/Dashboard.tsx
+++ b/src/pages/manager/Dashboard.tsx
@@ -36,8 +36,8 @@ const ManagerDashboard = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Manager Dashboard</h1>
-          <p className="text-gray-600">Welcome back, {profile?.full_name || 'Manager'}</p>
+          <h1 className="text-3xl font-bold text-foreground">Manager Dashboard</h1>
+          <p className="text-muted-foreground">Welcome back, {profile?.full_name || 'Manager'}</p>
         </div>
         <div className="flex items-center gap-3">
           <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">

--- a/src/pages/manager/LeadManagement.tsx
+++ b/src/pages/manager/LeadManagement.tsx
@@ -50,7 +50,7 @@ const ManagerLeadManagement = () => {
       case 'high': return <AlertTriangle className="h-4 w-4 text-red-500" />;
       case 'medium': return <Clock className="h-4 w-4 text-yellow-500" />;
       case 'low': return <CheckCircle className="h-4 w-4 text-green-500" />;
-      default: return <Clock className="h-4 w-4 text-gray-500" />;
+      default: return <Clock className="h-4 w-4 text-muted-foreground" />;
     }
   };
 
@@ -59,8 +59,8 @@ const ManagerLeadManagement = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Team Lead Management</h1>
-          <p className="text-gray-600">Monitor and manage your team's lead pipeline</p>
+          <h1 className="text-3xl font-bold text-foreground">Team Lead Management</h1>
+          <p className="text-muted-foreground">Monitor and manage your team's lead pipeline</p>
         </div>
         <div className="flex items-center gap-3">
           <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
@@ -207,15 +207,15 @@ const ManagerLeadManagement = () => {
                       </div>
                       <div>
                         <h4 className="font-medium">{lead.name}</h4>
-                        <p className="text-sm text-gray-600">{lead.company} • {lead.email}</p>
-                        <p className="text-xs text-gray-500">Assigned to: {lead.assignedTo}</p>
+                        <p className="text-sm text-muted-foreground">{lead.company} • {lead.email}</p>
+                        <p className="text-xs text-muted-foreground">Assigned to: {lead.assignedTo}</p>
                       </div>
                     </div>
                     <div className="flex items-center gap-4">
                       <div className="text-right">
                         <p className="text-sm font-medium">Score: {lead.score}%</p>
-                        <p className="text-xs text-gray-500">{lead.daysInPipeline} days in pipeline</p>
-                        <p className="text-xs text-gray-500">Last: {lead.lastActivity}</p>
+                        <p className="text-xs text-muted-foreground">{lead.daysInPipeline} days in pipeline</p>
+                        <p className="text-xs text-muted-foreground">Last: {lead.lastActivity}</p>
                       </div>
                       <Badge className={getStatusColor(lead.status)}>
                         {lead.status}
@@ -246,10 +246,10 @@ const ManagerLeadManagement = () => {
                         <div key={lead.id} className="flex items-center justify-between p-2 bg-gray-50 rounded">
                           <div>
                             <p className="font-medium text-sm">{lead.name}</p>
-                            <p className="text-xs text-gray-600">{lead.company}</p>
+                            <p className="text-xs text-muted-foreground">{lead.company}</p>
                           </div>
                           <div className="flex items-center gap-2">
-                            <span className="text-xs text-gray-500">{lead.score}%</span>
+                            <span className="text-xs text-muted-foreground">{lead.score}%</span>
                             <Badge className={getStatusColor(lead.status)}>
                               {lead.status}
                             </Badge>
@@ -278,8 +278,8 @@ const ManagerLeadManagement = () => {
                   <div key={lead.id} className="flex items-center justify-between p-4 border-l-4 border-red-400 bg-red-50 rounded-lg">
                     <div>
                       <h4 className="font-medium">{lead.name}</h4>
-                      <p className="text-sm text-gray-600">{lead.company} • Assigned to: {lead.assignedTo}</p>
-                      <p className="text-xs text-gray-500">Score: {lead.score}% • {lead.daysInPipeline} days in pipeline</p>
+                      <p className="text-sm text-muted-foreground">{lead.company} • Assigned to: {lead.assignedTo}</p>
+                      <p className="text-xs text-muted-foreground">Score: {lead.score}% • {lead.daysInPipeline} days in pipeline</p>
                     </div>
                     <div className="flex items-center gap-2">
                       <Badge variant="destructive">High Priority</Badge>
@@ -306,8 +306,8 @@ const ManagerLeadManagement = () => {
                   <div key={lead.id} className="flex items-center justify-between p-4 border-l-4 border-yellow-400 bg-yellow-50 rounded-lg">
                     <div>
                       <h4 className="font-medium">{lead.name}</h4>
-                      <p className="text-sm text-gray-600">{lead.company} • Assigned to: {lead.assignedTo}</p>
-                      <p className="text-xs text-gray-500">Last activity: {lead.lastActivity} • {lead.daysInPipeline} days ago</p>
+                      <p className="text-sm text-muted-foreground">{lead.company} • Assigned to: {lead.assignedTo}</p>
+                      <p className="text-xs text-muted-foreground">Last activity: {lead.lastActivity} • {lead.daysInPipeline} days ago</p>
                     </div>
                     <div className="flex items-center gap-2">
                       <Badge variant="outline" className="bg-yellow-100 text-yellow-800">Stalled</Badge>

--- a/src/pages/manager/Reports.tsx
+++ b/src/pages/manager/Reports.tsx
@@ -8,7 +8,7 @@ const Reports: React.FC = () => {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+        <h1 className="text-3xl font-bold text-foreground dark:text-white">
           Reports & Analytics
         </h1>
         <Button>
@@ -97,7 +97,7 @@ const Reports: React.FC = () => {
             <CardTitle>Custom Reports</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-gray-600 dark:text-gray-400 mb-4">
+            <p className="text-muted-foreground dark:text-gray-400 mb-4">
               Create custom reports with specific metrics and date ranges.
             </p>
             <Button className="w-full">

--- a/src/pages/manager/Security.tsx
+++ b/src/pages/manager/Security.tsx
@@ -17,7 +17,7 @@ const SecurityPage: React.FC = () => {
           <CardContent className="p-8 text-center">
             <Lock className="h-12 w-12 text-gray-400 mx-auto mb-4" />
             <h2 className="text-xl font-semibold text-gray-700 mb-2">Access Restricted</h2>
-            <p className="text-gray-600">Security dashboard is only available to managers and administrators.</p>
+            <p className="text-muted-foreground">Security dashboard is only available to managers and administrators.</p>
           </CardContent>
         </Card>
       </div>
@@ -28,8 +28,8 @@ const SecurityPage: React.FC = () => {
     <div className="p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Security Center</h1>
-          <p className="text-gray-600 mt-2">
+          <h1 className="text-3xl font-bold text-foreground">Security Center</h1>
+          <p className="text-muted-foreground mt-2">
             Monitor and manage AI security posture, data protection, and access controls
           </p>
         </div>

--- a/src/pages/manager/Settings.tsx
+++ b/src/pages/manager/Settings.tsx
@@ -66,8 +66,8 @@ const ManagerSettings = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">Manager Settings</h1>
-          <p className="text-gray-600">Configure your management preferences and team settings</p>
+          <h1 className="text-3xl font-bold text-foreground">Manager Settings</h1>
+          <p className="text-muted-foreground">Configure your management preferences and team settings</p>
         </div>
         <Button onClick={handleSave}>
           <Save className="h-4 w-4 mr-2" />
@@ -147,7 +147,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Email Notifications</h4>
-                    <p className="text-sm text-gray-600">Receive email updates about important events</p>
+                    <p className="text-sm text-muted-foreground">Receive email updates about important events</p>
                   </div>
                   <Switch
                     checked={settings.emailNotifications}
@@ -158,7 +158,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Push Notifications</h4>
-                    <p className="text-sm text-gray-600">Get real-time notifications in the browser</p>
+                    <p className="text-sm text-muted-foreground">Get real-time notifications in the browser</p>
                   </div>
                   <Switch
                     checked={settings.pushNotifications}
@@ -169,7 +169,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Weekly Reports</h4>
-                    <p className="text-sm text-gray-600">Automated weekly team performance reports</p>
+                    <p className="text-sm text-muted-foreground">Automated weekly team performance reports</p>
                   </div>
                   <Switch
                     checked={settings.weeklyReports}
@@ -180,7 +180,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Deal Alerts</h4>
-                    <p className="text-sm text-gray-600">Notifications for high-value deals and closures</p>
+                    <p className="text-sm text-muted-foreground">Notifications for high-value deals and closures</p>
                   </div>
                   <Switch
                     checked={settings.dealAlerts}
@@ -191,7 +191,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Team Updates</h4>
-                    <p className="text-sm text-gray-600">Updates about team member activities</p>
+                    <p className="text-sm text-muted-foreground">Updates about team member activities</p>
                   </div>
                   <Switch
                     checked={settings.teamUpdates}
@@ -216,7 +216,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">AI Suggestions</h4>
-                    <p className="text-sm text-gray-600">Enable AI-powered recommendations and insights</p>
+                    <p className="text-sm text-muted-foreground">Enable AI-powered recommendations and insights</p>
                   </div>
                   <Switch
                     checked={settings.aiSuggestions}
@@ -227,7 +227,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Voice Commands</h4>
-                    <p className="text-sm text-gray-600">Control the AI assistant with voice commands</p>
+                    <p className="text-sm text-muted-foreground">Control the AI assistant with voice commands</p>
                   </div>
                   <Switch
                     checked={settings.voiceCommands}
@@ -238,7 +238,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Auto Analysis</h4>
-                    <p className="text-sm text-gray-600">Automatic analysis of team performance data</p>
+                    <p className="text-sm text-muted-foreground">Automatic analysis of team performance data</p>
                   </div>
                   <Switch
                     checked={settings.autoAnalysis}
@@ -249,7 +249,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Smart Insights</h4>
-                    <p className="text-sm text-gray-600">Proactive insights and optimization suggestions</p>
+                    <p className="text-sm text-muted-foreground">Proactive insights and optimization suggestions</p>
                   </div>
                   <Switch
                     checked={settings.smartInsights}
@@ -298,7 +298,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Auto Assignment</h4>
-                    <p className="text-sm text-gray-600">Automatically assign new leads to team members</p>
+                    <p className="text-sm text-muted-foreground">Automatically assign new leads to team members</p>
                   </div>
                   <Switch
                     checked={settings.autoAssignment}
@@ -309,7 +309,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Performance Tracking</h4>
-                    <p className="text-sm text-gray-600">Track individual team member performance</p>
+                    <p className="text-sm text-muted-foreground">Track individual team member performance</p>
                   </div>
                   <Switch
                     checked={settings.performanceTracking}
@@ -334,7 +334,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Two-Factor Authentication</h4>
-                    <p className="text-sm text-gray-600">Add an extra layer of security to your account</p>
+                    <p className="text-sm text-muted-foreground">Add an extra layer of security to your account</p>
                   </div>
                   <Switch
                     checked={settings.twoFactor}
@@ -345,7 +345,7 @@ const ManagerSettings = () => {
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="font-medium">Data Export</h4>
-                    <p className="text-sm text-gray-600">Allow data export functionality</p>
+                    <p className="text-sm text-muted-foreground">Allow data export functionality</p>
                   </div>
                   <Switch
                     checked={settings.dataExport}
@@ -364,7 +364,7 @@ const ManagerSettings = () => {
                   min="15"
                   max="480"
                 />
-                <p className="text-sm text-gray-600">Automatically log out after period of inactivity</p>
+                <p className="text-sm text-muted-foreground">Automatically log out after period of inactivity</p>
               </div>
             </CardContent>
           </Card>

--- a/src/pages/manager/TeamManagement.tsx
+++ b/src/pages/manager/TeamManagement.tsx
@@ -7,7 +7,7 @@ const TeamManagement: React.FC = () => {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+        <h1 className="text-3xl font-bold text-foreground dark:text-white">
           Team Management
         </h1>
       </div>
@@ -71,7 +71,7 @@ const TeamManagement: React.FC = () => {
           <CardTitle>Team Overview</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-gray-600 dark:text-gray-400">
+          <p className="text-muted-foreground dark:text-gray-400">
             Detailed team management features will be implemented here, including
             performance tracking, goal setting, and team collaboration tools.
           </p>


### PR DESCRIPTION
## Summary
- use text-foreground and text-muted-foreground on manager pages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b54a2fd08328b1f50e37bc5e40e1