### PR TITLE
Add Sales Rep color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,3 +146,14 @@ const { data, error } = await supabase.functions.invoke('elevenlabs-speech', {
 ```
 
 The client now uses this function for speech synthesis instead of reading `VITE_ELEVENLABS_API_KEY` directly.
+
+## Design System Colors
+
+Custom Tailwind classes such as `bg-salesBlue` or `text-salesGreen` rely on colors defined in `tailwind.config.ts` under `theme.extend.colors`. These Sales Rep palette colors are:
+
+- **salesBlue** – `#4A3AFF` (light: `#6B73FF`, dark: `#3B2ECC`)
+- **salesCyan** – `#38bdf8` (light: `#58ddf8`, dark: `#189dd8`)
+- **salesGreen** – `#22c55e` (light: `#42e57e`, dark: `#16a34a`)
+- **salesRed** – `#ef4444` (light: `#f87171`, dark: `#dc2626`)
+
+These colors match the Sales Rep design system and can be used directly in Tailwind utility classes.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -94,13 +94,33 @@ export default {
 					light: '#42e57e',
 					dark: '#16a34a',
 				},
-				danger: {
-					DEFAULT: '#ef4444',
-					light: '#f87171',
-					dark: '#dc2626',
-				},
-				neutral: {
-					50: '#f8fafc',
+                                danger: {
+                                        DEFAULT: '#ef4444',
+                                        light: '#f87171',
+                                        dark: '#dc2626',
+                                },
+                                salesBlue: {
+                                        DEFAULT: '#4A3AFF',
+                                        light: '#6B73FF',
+                                        dark: '#3B2ECC',
+                                },
+                                salesCyan: {
+                                        DEFAULT: '#38bdf8',
+                                        light: '#58ddf8',
+                                        dark: '#189dd8',
+                                },
+                                salesGreen: {
+                                        DEFAULT: '#22c55e',
+                                        light: '#42e57e',
+                                        dark: '#16a34a',
+                                },
+                                salesRed: {
+                                        DEFAULT: '#ef4444',
+                                        light: '#f87171',
+                                        dark: '#dc2626',
+                                },
+                                neutral: {
+                                        50: '#f8fafc',
 					100: '#f1f5f9',
 					200: '#e2e8f0',
 					300: '#cbd5e1',


### PR DESCRIPTION
## Summary
- define custom colors `salesBlue`, `salesCyan`, `salesGreen`, and `salesRed` in Tailwind
- document the Sales Rep palette in README

## Testing
- `npm test` *(fails: Transform failed with 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6846b54d3bb0832896dea6d9552b95d9