### PR TITLE
Unify Manager card styling

### DIFF
--- a/src/components/Manager/CompanyDashboard.tsx
+++ b/src/components/Manager/CompanyDashboard.tsx
@@ -77,7 +77,7 @@ const CompanyDashboard = () => {
     <div className="space-y-6">
       {/* Key Metrics */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Total Leads</CardTitle>
             <Users className="h-4 w-4 text-muted-foreground" />
@@ -90,7 +90,7 @@ const CompanyDashboard = () => {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Pipeline Value</CardTitle>
             <DollarSign className="h-4 w-4 text-muted-foreground" />
@@ -103,7 +103,7 @@ const CompanyDashboard = () => {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Conversion Rate</CardTitle>
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
@@ -116,7 +116,7 @@ const CompanyDashboard = () => {
           </CardContent>
         </Card>
 
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Avg Response Time</CardTitle>
             <Clock className="h-4 w-4 text-muted-foreground" />
@@ -133,7 +133,7 @@ const CompanyDashboard = () => {
       {/* Charts and Analytics */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Rep Performance */}
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader>
             <CardTitle>Rep Performance Comparison</CardTitle>
           </CardHeader>
@@ -153,7 +153,7 @@ const CompanyDashboard = () => {
         </Card>
 
         {/* Lead Sources */}
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader>
             <CardTitle>Lead Sources Distribution</CardTitle>
           </CardHeader>
@@ -182,7 +182,7 @@ const CompanyDashboard = () => {
       </div>
 
       {/* Pipeline Funnel */}
-      <Card>
+      <Card className="rounded-lg shadow-md">
         <CardHeader>
           <CardTitle>Sales Pipeline Funnel</CardTitle>
         </CardHeader>
@@ -202,7 +202,7 @@ const CompanyDashboard = () => {
       </Card>
 
       {/* AI Insights */}
-      <Card>
+      <Card className="rounded-lg shadow-md">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-blue-600" />
@@ -232,7 +232,7 @@ const CompanyDashboard = () => {
       </Card>
 
       {/* Recent Team Activity */}
-      <Card>
+      <Card className="rounded-lg shadow-md">
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Recent Team Activity</CardTitle>
           <Button variant="outline" size="sm">

--- a/src/components/Manager/IntegrationsTab.tsx
+++ b/src/components/Manager/IntegrationsTab.tsx
@@ -136,7 +136,7 @@ const IntegrationsTab = () => {
           const IconComponent = integration.icon;
           
           return (
-            <Card key={integration.id} className="hover:shadow-lg transition-shadow">
+            <Card key={integration.id} className="rounded-lg shadow-md hover:shadow-lg transition-shadow">
               <CardHeader className="pb-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
@@ -200,7 +200,7 @@ const IntegrationsTab = () => {
       </div>
 
       {/* Integration Benefits */}
-      <Card>
+      <Card className="rounded-lg shadow-md">
         <CardHeader>
           <CardTitle>What happens when you connect?</CardTitle>
         </CardHeader>

--- a/src/components/Manager/KnowledgeTab.tsx
+++ b/src/components/Manager/KnowledgeTab.tsx
@@ -6,7 +6,7 @@ import { Upload, Search, RefreshCw } from 'lucide-react';
 const KnowledgeTab: React.FC = () => {
   return (
     <div className="space-y-6">
-      <Card>
+      <Card className="rounded-lg shadow-md">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Upload className="h-5 w-5" />
@@ -21,7 +21,7 @@ const KnowledgeTab: React.FC = () => {
         </CardContent>
       </Card>
 
-      <Card>
+      <Card className="rounded-lg shadow-md">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Search className="h-5 w-5" />

--- a/src/components/Manager/LeadAssignment.tsx
+++ b/src/components/Manager/LeadAssignment.tsx
@@ -5,7 +5,7 @@ import { Users, UserPlus } from 'lucide-react';
 
 const LeadAssignment: React.FC = () => {
   return (
-    <Card>
+    <Card className="rounded-lg shadow-md">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Users className="h-5 w-5" />

--- a/src/components/Manager/ManagerBookingSystem.tsx
+++ b/src/components/Manager/ManagerBookingSystem.tsx
@@ -12,7 +12,7 @@ interface ManagerBookingSystemProps {
 
 const ManagerBookingSystem: React.FC<ManagerBookingSystemProps> = ({ demoMode }) => {
   return (
-    <Card>
+    <Card className="rounded-lg shadow-md">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Calendar className="h-5 w-5 text-salesBlue" />
@@ -28,7 +28,7 @@ const ManagerBookingSystem: React.FC<ManagerBookingSystemProps> = ({ demoMode })
             Regular 1-on-1s improve retention by 41% and performance by 27%.
           </p>
           
-          <Card className="bg-slate-50">
+          <Card className="bg-slate-50 rounded-lg shadow-md">
             <CardContent className="p-4">
               <h4 className="font-medium mb-2">Upcoming Sessions</h4>
               {demoMode ? (

--- a/src/components/Manager/ManagerEscalationCenter.tsx
+++ b/src/components/Manager/ManagerEscalationCenter.tsx
@@ -10,7 +10,7 @@ interface ManagerEscalationCenterProps {
 
 const ManagerEscalationCenter: React.FC<ManagerEscalationCenterProps> = ({ demoMode }) => {
   return (
-    <Card className="border border-salesRed-light">
+    <Card className="border border-salesRed-light rounded-lg shadow-md">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-salesRed">
           <AlertCircle className="h-5 w-5" />

--- a/src/components/Manager/ManagerOverviewCards.tsx
+++ b/src/components/Manager/ManagerOverviewCards.tsx
@@ -43,7 +43,7 @@ const ManagerOverviewCards: React.FC<ManagerOverviewCardsProps> = ({
       </div>
       
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardContent className="p-4 flex flex-col items-center justify-center text-center">
             <Users className="h-8 w-8 text-salesBlue mb-2" />
             <p className="text-sm text-muted-foreground">Team Members</p>
@@ -51,7 +51,7 @@ const ManagerOverviewCards: React.FC<ManagerOverviewCardsProps> = ({
           </CardContent>
         </Card>
         
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardContent className="p-4 flex flex-col items-center justify-center text-center">
             <Award className="h-8 w-8 text-salesGreen mb-2" />
             <p className="text-sm text-muted-foreground">Top Performer</p>
@@ -63,7 +63,7 @@ const ManagerOverviewCards: React.FC<ManagerOverviewCardsProps> = ({
           </CardContent>
         </Card>
         
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardContent className="p-4 flex flex-col items-center justify-center text-center">
             <AlertCircle className="h-8 w-8 text-salesRed mb-2" />
             <p className="text-sm text-muted-foreground">Burnout Risk</p>
@@ -73,7 +73,7 @@ const ManagerOverviewCards: React.FC<ManagerOverviewCardsProps> = ({
           </CardContent>
         </Card>
         
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardContent className="p-4 flex flex-col items-center justify-center text-center">
             <CheckCircle className="h-8 w-8 text-salesCyan mb-2" />
             <p className="text-sm text-muted-foreground">Team Win Rate</p>

--- a/src/components/Manager/ManagerRecognitionEngine.tsx
+++ b/src/components/Manager/ManagerRecognitionEngine.tsx
@@ -6,7 +6,7 @@ import { Award, Trophy, Bell } from 'lucide-react';
 
 const ManagerRecognitionEngine = () => {
   return (
-    <Card>
+    <Card className="rounded-lg shadow-md">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Award className="h-5 w-5 text-salesGreen" />
@@ -23,7 +23,7 @@ const ManagerRecognitionEngine = () => {
           </p>
           
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardContent className="p-4 text-center">
                 <Award className="h-8 w-8 text-salesCyan mx-auto mb-2" />
                 <h3 className="font-medium mb-1">Personal Awards</h3>
@@ -36,7 +36,7 @@ const ManagerRecognitionEngine = () => {
               </CardContent>
             </Card>
             
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardContent className="p-4 text-center">
                 <Trophy className="h-8 w-8 text-salesGreen mx-auto mb-2" />
                 <h3 className="font-medium mb-1">Team Challenges</h3>
@@ -49,7 +49,7 @@ const ManagerRecognitionEngine = () => {
               </CardContent>
             </Card>
             
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardContent className="p-4 text-center">
                 <Bell className="h-8 w-8 text-salesBlue mx-auto mb-2" />
                 <h3 className="font-medium mb-1">Public Recognition</h3>

--- a/src/components/Manager/ManagerTeamTable.tsx
+++ b/src/components/Manager/ManagerTeamTable.tsx
@@ -51,7 +51,7 @@ const ManagerTeamTable: React.FC<ManagerTeamTableProps> = ({ teamMembers }) => {
   };
 
   return (
-    <Card>
+    <Card className="rounded-lg shadow-md">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <Users className="h-5 w-5" />

--- a/src/components/Manager/MarketingAnalytics.tsx
+++ b/src/components/Manager/MarketingAnalytics.tsx
@@ -5,7 +5,7 @@ import { BarChart3, RefreshCw } from 'lucide-react';
 
 const MarketingAnalytics: React.FC = () => {
   return (
-    <Card>
+    <Card className="rounded-lg shadow-md">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <BarChart3 className="h-5 w-5" />

--- a/src/pages/ManagerAnalytics.tsx
+++ b/src/pages/ManagerAnalytics.tsx
@@ -158,7 +158,7 @@ const ManagerAnalytics = () => {
               <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
                 {/* Left Column - AI Alerts */}
                 <div className="lg:col-span-1 space-y-4">
-                  <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardHeader className="pb-3">
                       <CardTitle className="text-lg flex items-center gap-2">
                         <AlertTriangle className="h-5 w-5 text-orange-500" />
@@ -181,7 +181,7 @@ const ManagerAnalytics = () => {
                     </CardContent>
                   </Card>
 
-                  <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardHeader className="pb-3">
                       <CardTitle className="text-lg flex items-center gap-2">
                         <Brain className="h-5 w-5 text-purple-500" />
@@ -206,7 +206,7 @@ const ManagerAnalytics = () => {
 
                 {/* Center Column - Rep Performance */}
                 <div className="lg:col-span-2 space-y-4">
-                  <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardHeader>
                       <CardTitle className="text-xl flex items-center gap-2">
                         <Users className="h-6 w-6 text-blue-500" />
@@ -250,7 +250,7 @@ const ManagerAnalytics = () => {
 
                 {/* Right Column - Quick Tools */}
                 <div className="lg:col-span-1 space-y-4">
-                  <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardHeader className="pb-3">
                       <CardTitle className="text-lg flex items-center gap-2">
                         <Target className="h-5 w-5 text-green-500" />
@@ -273,7 +273,7 @@ const ManagerAnalytics = () => {
                     </CardContent>
                   </Card>
 
-                  <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardHeader className="pb-3">
                       <CardTitle className="text-lg flex items-center gap-2">
                         <Clock className="h-5 w-5 text-orange-500" />
@@ -301,7 +301,7 @@ const ManagerAnalytics = () => {
             <TabsContent value="marketing">
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <div className="lg:col-span-2">
-                  <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardHeader>
                       <CardTitle className="text-xl flex items-center gap-2">
                         <TrendingUp className="h-6 w-6 text-green-500" />
@@ -363,7 +363,7 @@ const ManagerAnalytics = () => {
             <TabsContent value="business">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 {businessMetrics.map((metric, index) => (
-                  <Card key={index} className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                  <Card key={index} className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                     <CardContent className="p-6">
                       <div className="flex justify-between items-start mb-4">
                         <div>
@@ -386,7 +386,7 @@ const ManagerAnalytics = () => {
 
             <TabsContent value="ai-activity">
               <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                   <CardHeader>
                     <CardTitle className="text-xl flex items-center gap-2">
                       <Brain className="h-6 w-6 text-purple-500" />
@@ -410,7 +410,7 @@ const ManagerAnalytics = () => {
                   </CardContent>
                 </Card>
 
-                <Card className="rounded-xl shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
+                <Card className="rounded-lg shadow-md hover:shadow-lg transition-all duration-300 hover:-translate-y-1">
                   <CardHeader>
                     <CardTitle className="text-xl">AI Learning Insights</CardTitle>
                   </CardHeader>

--- a/src/pages/manager/Analytics.tsx
+++ b/src/pages/manager/Analytics.tsx
@@ -55,7 +55,7 @@ const ManagerAnalytics = () => {
         <TabsContent value="overview" className="space-y-6">
           {/* Key Metrics Overview */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Monthly ARR</CardTitle>
                 <DollarSign className="h-4 w-4 text-muted-foreground" />
@@ -68,7 +68,7 @@ const ManagerAnalytics = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">CAC</CardTitle>
                 <Target className="h-4 w-4 text-muted-foreground" />
@@ -81,7 +81,7 @@ const ManagerAnalytics = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">LTV</CardTitle>
                 <TrendingUp className="h-4 w-4 text-muted-foreground" />
@@ -94,7 +94,7 @@ const ManagerAnalytics = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">Conversion Rate</CardTitle>
                 <BarChart3 className="h-4 w-4 text-muted-foreground" />
@@ -109,7 +109,7 @@ const ManagerAnalytics = () => {
           </div>
 
           {/* AI Insights */}
-          <Card>
+          <Card className="rounded-lg shadow-md">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Brain className="h-5 w-5 text-blue-600" />
@@ -142,7 +142,7 @@ const ManagerAnalytics = () => {
         </TabsContent>
 
         <TabsContent value="sales-reps" className="space-y-6">
-          <Card>
+          <Card className="rounded-lg shadow-md">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Users className="h-5 w-5" />
@@ -186,7 +186,7 @@ const ManagerAnalytics = () => {
 
         <TabsContent value="marketing" className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>Lead Sources</CardTitle>
               </CardHeader>
@@ -210,7 +210,7 @@ const ManagerAnalytics = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>Campaign Performance</CardTitle>
               </CardHeader>
@@ -235,7 +235,7 @@ const ManagerAnalytics = () => {
         </TabsContent>
 
         <TabsContent value="funnels" className="space-y-6">
-          <Card>
+          <Card className="rounded-lg shadow-md">
             <CardHeader>
               <CardTitle>Booking Flow Conversions</CardTitle>
             </CardHeader>
@@ -270,7 +270,7 @@ const ManagerAnalytics = () => {
 
         <TabsContent value="retention" className="space-y-6">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>Customer Retention Metrics</CardTitle>
               </CardHeader>
@@ -296,7 +296,7 @@ const ManagerAnalytics = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>Churn Risk Analysis</CardTitle>
               </CardHeader>

--- a/src/pages/manager/CRMIntegrations.tsx
+++ b/src/pages/manager/CRMIntegrations.tsx
@@ -17,7 +17,7 @@ const ManagerCRMIntegrations = () => {
 
         <div className="grid gap-6 mb-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
@@ -29,7 +29,7 @@ const ManagerCRMIntegrations = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
@@ -41,7 +41,7 @@ const ManagerCRMIntegrations = () => {
               </CardContent>
             </Card>
 
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardContent className="p-6">
                 <div className="flex items-center justify-between">
                   <div>
@@ -55,7 +55,7 @@ const ManagerCRMIntegrations = () => {
           </div>
         </div>
 
-        <Card>
+        <Card className="rounded-lg shadow-md">
           <CardHeader>
             <CardTitle>Integration Management</CardTitle>
           </CardHeader>

--- a/src/pages/manager/CompanyBrain.tsx
+++ b/src/pages/manager/CompanyBrain.tsx
@@ -69,7 +69,7 @@ const ManagerCompanyBrain = () => {
           <TabsContent value="overview" className="mt-6">
             <div className="grid gap-6">
               <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-                <Card>
+                <Card className="rounded-lg shadow-md">
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between">
                       <div>
@@ -81,7 +81,7 @@ const ManagerCompanyBrain = () => {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="rounded-lg shadow-md">
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between">
                       <div>
@@ -93,7 +93,7 @@ const ManagerCompanyBrain = () => {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="rounded-lg shadow-md">
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between">
                       <div>
@@ -105,7 +105,7 @@ const ManagerCompanyBrain = () => {
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="rounded-lg shadow-md">
                   <CardContent className="p-6">
                     <div className="flex items-center justify-between">
                       <div>
@@ -118,7 +118,7 @@ const ManagerCompanyBrain = () => {
                 </Card>
               </div>
 
-              <Card>
+              <Card className="rounded-lg shadow-md">
                 <CardHeader>
                   <CardTitle>Recent AI Activity</CardTitle>
                 </CardHeader>
@@ -163,7 +163,7 @@ const ManagerCompanyBrain = () => {
           </TabsContent>
 
           <TabsContent value="knowledge" className="mt-6">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>Knowledge Base Management</CardTitle>
               </CardHeader>
@@ -183,7 +183,7 @@ const ManagerCompanyBrain = () => {
                   </div>
 
                   <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
-                    <Card>
+                    <Card className="rounded-lg shadow-md">
                       <CardContent className="p-4">
                         <h4 className="font-medium mb-2">Sales Playbooks</h4>
                         <p className="text-sm text-slate-600 mb-3">342 articles</p>
@@ -191,7 +191,7 @@ const ManagerCompanyBrain = () => {
                       </CardContent>
                     </Card>
                     
-                    <Card>
+                    <Card className="rounded-lg shadow-md">
                       <CardContent className="p-4">
                         <h4 className="font-medium mb-2">Product Information</h4>
                         <p className="text-sm text-slate-600 mb-3">189 articles</p>
@@ -199,7 +199,7 @@ const ManagerCompanyBrain = () => {
                       </CardContent>
                     </Card>
 
-                    <Card>
+                    <Card className="rounded-lg shadow-md">
                       <CardContent className="p-4">
                         <h4 className="font-medium mb-2">Competitor Analysis</h4>
                         <p className="text-sm text-slate-600 mb-3">96 articles</p>
@@ -221,7 +221,7 @@ const ManagerCompanyBrain = () => {
           </TabsContent>
 
           <TabsContent value="insights" className="mt-6">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>AI-Generated Insights</CardTitle>
               </CardHeader>
@@ -280,7 +280,7 @@ const ManagerCompanyBrain = () => {
           </TabsContent>
 
           <TabsContent value="settings" className="mt-6">
-            <Card>
+            <Card className="rounded-lg shadow-md">
               <CardHeader>
                 <CardTitle>Company Brain Settings</CardTitle>
               </CardHeader>


### PR DESCRIPTION
## Summary
- align Manager dashboards with Sales Rep OS
- use `rounded-lg shadow-md` styling for card containers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846b54e8760832883a6b9e75d67e06e