### PR TITLE
Improve OS detection in SystemMonitor

### DIFF
--- a/src/__tests__/dialerInteractions.test.tsx
+++ b/src/__tests__/dialerInteractions.test.tsx
@@ -96,7 +96,7 @@ it('sends SMS and email with proper parameters', async () => {
   // Email action
   fireEvent.click(screen.getByRole('button', { name: /^email$/i }));
   const emailArea = screen.getByPlaceholderText('Compose your follow-up email...');
-  fireEvent.change(emailArea, { target: { value: 'hi there' });
+  fireEvent.change(emailArea, { target: { value: 'hi there' } });
   fireEvent.click(screen.getByRole('button', { name: /send email/i }));
   expect(sendEmailMock).toHaveBeenCalledWith(
     baseLead.email,

--- a/src/pages/developer/SystemMonitor.tsx
+++ b/src/pages/developer/SystemMonitor.tsx
@@ -25,11 +25,29 @@ interface SystemResource {
 const SystemMonitor: React.FC = () => {
   const [resources, setResources] = useState<SystemResource[]>([]);
   const [lastUpdate, setLastUpdate] = useState<Date>(new Date());
+  const [osInfo, setOsInfo] = useState<string>('');
 
   useEffect(() => {
     loadSystemResources();
     const interval = setInterval(loadSystemResources, 5000);
     return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const detectOS = () => {
+      if (typeof navigator === 'undefined') {
+        return 'Unknown';
+      }
+      const ua = navigator.userAgent;
+      if (/windows/i.test(ua)) return 'Windows';
+      if (/macintosh|mac os x/i.test(ua)) return 'macOS';
+      if (/android/i.test(ua)) return 'Android';
+      if (/iphone|ipad|ipod/i.test(ua)) return 'iOS';
+      if (/linux/i.test(ua)) return 'Linux';
+      return 'Unknown';
+    };
+
+    setOsInfo(detectOS());
   }, []);
 
   const loadSystemResources = () => {
@@ -142,7 +160,7 @@ const SystemMonitor: React.FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-slate-300">
             <div>
               <h4 className="font-medium mb-2">Server Details</h4>
-              <p className="text-sm">OS: Linux Ubuntu 20.04</p>
+              <p className="text-sm">OS: {osInfo || 'Unknown'}</p>
               <p className="text-sm">Runtime: Node.js 18.x</p>
               <p className="text-sm">Framework: React 18 + Vite</p>
             </div>


### PR DESCRIPTION
## Summary
- detect operating system at runtime in `SystemMonitor`
- fix syntax error in `dialerInteractions.test.tsx`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846bb9eafc48328ad8b80b4c92341dd