### PR TITLE
Enable Developer OS login

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ When deploying the Supabase functions, set the `CORS_ALLOWED_ORIGINS` environmen
 variable with a comma-separated list of domains allowed to call the functions.
 Only requests from these origins will be permitted.
 
+## Developer OS account
+
+Create the default developer account using the provided script. Ensure the
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` environment variables are set and
+run:
+
+```sh
+npm run create:developer
+```
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint .",
     "test": "vitest",
     "test:watch": "vitest",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "create:developer": "node scripts/createDeveloper.js"
   },
   "dependencies": {
     "@11labs/react": "^0.1.4",

--- a/scripts/createDeveloper.js
+++ b/scripts/createDeveloper.js
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceKey) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceKey);
+
+async function main() {
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: 'krishdev@tsam.com',
+    password: 'badabing2024',
+    email_confirm: true,
+    user_metadata: { full_name: 'Krish Dev', role: 'developer' }
+  });
+
+  if (error || !data.user) {
+    console.error('Error creating user:', error);
+    return;
+  }
+
+  const userId = data.user.id;
+
+  const { error: profileError } = await supabase.from('profiles').upsert({
+    id: userId,
+    full_name: 'Krish Dev',
+    role: 'developer',
+    company_id: userId
+  });
+
+  if (profileError) {
+    console.error('Error creating profile:', profileError);
+    return;
+  }
+
+  console.log('Developer user created with id:', userId);
+}
+
+main();

--- a/src/components/Navigation/navigationUtils.ts
+++ b/src/components/Navigation/navigationUtils.ts
@@ -10,6 +10,8 @@ export const getDashboardUrl = (
   switch (role) {
     case 'admin':
       return '/admin-dashboard';
+    case 'developer':
+      return '/developer/dashboard';
     case 'manager':
       return '/manager/dashboard';
     case 'sales_rep':

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -33,6 +33,17 @@ const AuthPage = () => {
     fullName: ''
   });
 
+  // Prefill credentials based on selected role
+  useEffect(() => {
+    if (selectedRole === 'developer') {
+      setFormData({ email: 'krishdev@tsam.com', password: 'badabing2024', fullName: '' });
+    } else if (selectedRole === 'manager') {
+      setFormData({ email: 'manager@salesos.com', password: 'manager123', fullName: '' });
+    } else {
+      setFormData({ email: 'sales.rep@company.com', password: 'fulluser123', fullName: '' });
+    }
+  }, [selectedRole]);
+
   // Show loading screen while auth state is being determined
   if (loading) {
     return <AuthLoadingScreen role={selectedRole} isDemoMode={isDemoMode()} />;
@@ -97,27 +108,38 @@ const AuthPage = () => {
         </div>
       
         <Tabs defaultValue={selectedRole} value={selectedRole} onValueChange={value => handleRoleChange(value as Role)} className="w-full">
-          <TabsList className="grid grid-cols-2 mb-8 bg-neutral-100 rounded-xl p-1">
+          <TabsList className="grid grid-cols-3 mb-8 bg-neutral-100 rounded-xl p-1">
             <TabsTrigger value="manager" className="flex items-center gap-2 rounded-lg data-[state=active]:bg-white data-[state=active]:text-primary data-[state=active]:shadow-sm transition-all">
               Manager
             </TabsTrigger>
             <TabsTrigger value="sales_rep" className="flex items-center gap-2 rounded-lg data-[state=active]:bg-white data-[state=active]:text-primary data-[state=active]:shadow-sm transition-all">
               Sales Rep
             </TabsTrigger>
+            <TabsTrigger value="developer" className="flex items-center gap-2 rounded-lg data-[state=active]:bg-white data-[state=active]:text-primary data-[state=active]:shadow-sm transition-all">
+              Developer
+            </TabsTrigger>
           </TabsList>
         
           <div className="space-y-6">
             <div className="text-center p-6 mb-6 border border-neutral-200 rounded-xl bg-neutral-50/50">
               <h3 className="font-semibold text-lg mb-2 font-poppins">
-                {selectedRole === 'manager' ? 'Manager Dashboard' : 'Sales Rep Dashboard'}
+                {selectedRole === 'manager'
+                  ? 'Manager Dashboard'
+                  : selectedRole === 'developer'
+                  ? 'Developer Dashboard'
+                  : 'Sales Rep Dashboard'}
               </h3>
               <p className="text-sm text-muted-foreground">
-                {selectedRole === 'manager' ? 'Team analysis, performance tracking & AI coaching' : 'Smart dialer, call scripts & AI sales assistant'}
+                {selectedRole === 'manager'
+                  ? 'Team analysis, performance tracking & AI coaching'
+                  : selectedRole === 'developer'
+                  ? 'System monitoring, logs & developer tools'
+                  : 'Smart dialer, call scripts & AI sales assistant'}
               </p>
             </div>
             
             <div className="flex flex-col space-y-4">
-              {isLogin ? <AuthLoginForm setIsTransitioning={setIsTransitioning} simulateLoginTransition={simulateLoginTransition} formData={{
+              {isLogin ? <AuthLoginForm selectedRole={selectedRole} setIsTransitioning={setIsTransitioning} simulateLoginTransition={simulateLoginTransition} formData={{
               email: formData.email,
               password: formData.password
             }} setFormData={(data: {

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -25,9 +25,19 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
   
   const handleDemoLogin = () => {
     // First fill in the form with demo credentials
-    const email = selectedRole === 'manager' ? 'manager@salesos.com' : 'rep@salesos.com';
-    const password = selectedRole === 'manager' ? 'manager123' : 'sales123';
-    
+    const email =
+      selectedRole === 'manager'
+        ? 'manager@salesos.com'
+        : selectedRole === 'developer'
+        ? 'krishdev@tsam.com'
+        : 'rep@salesos.com';
+    const password =
+      selectedRole === 'manager'
+        ? 'manager123'
+        : selectedRole === 'developer'
+        ? 'badabing2024'
+        : 'sales123';
+
     setFormData({ email, password });
   };
   
@@ -35,9 +45,12 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
     // Clear any existing auth data first
     localStorage.clear();
     sessionStorage.clear();
-    
+
     // Skip the form and directly log in with demo mode
     logger.info("Direct demo login with role:", selectedRole);
+    if (selectedRole === 'developer') {
+      return;
+    }
     initializeDemoMode(selectedRole);
     setIsTransitioning(true);
     
@@ -65,17 +78,23 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
           Fill in Demo Credentials
         </Button>
         
-        <Button
-          onClick={handleDirectDemoLogin}
-          variant="default"
-          className="w-full py-2 bg-salesBlue hover:bg-salesBlue/90 text-sm font-medium transition-colors"
-        >
-          Quick Demo Login
-        </Button>
+        {selectedRole !== 'developer' && (
+          <Button
+            onClick={handleDirectDemoLogin}
+            variant="default"
+            className="w-full py-2 bg-salesBlue hover:bg-salesBlue/90 text-sm font-medium transition-colors"
+          >
+            Quick Demo Login
+          </Button>
+        )}
       </div>
-      
+
       <p className="text-xs text-center text-muted-foreground mt-3">
-        {selectedRole === 'manager' ? 'Demo Manager Account' : 'Demo Sales Rep Account'}
+        {selectedRole === 'manager'
+          ? 'Demo Manager Account'
+          : selectedRole === 'developer'
+          ? 'Use developer credentials to log in'
+          : 'Demo Sales Rep Account'}
       </p>
     </div>
   );

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
+import { Role } from '@/contexts/auth/types';
 interface AuthLoginFormProps {
   setIsTransitioning: (value: boolean) => void;
   simulateLoginTransition: () => void;
@@ -20,12 +21,14 @@ interface AuthLoginFormProps {
     email: string;
     password: string;
   }) => void;
+  selectedRole?: Role;
 }
 const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
   setIsTransitioning,
   simulateLoginTransition,
   formData: externalFormData,
-  setFormData: externalSetFormData
+  setFormData: externalSetFormData,
+  selectedRole
 }) => {
   const {
     signIn
@@ -101,7 +104,7 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
             <div className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-b-transparent"></div>
             Logging in...
           </> : <>
-            <LogIn className="mr-2 h-4 w-4" /> Login as Full User
+            <LogIn className="mr-2 h-4 w-4" /> Login as {selectedRole === 'developer' ? 'Developer' : 'Full User'}
           </>}
       </Button>
       


### PR DESCRIPTION
## Summary
- add Developer OS tab on auth page
- prefill login data for developer role
- show dev option in demo controls and update navigation util
- allow customizing login form label for developer
- provide script for creating developer Supabase user
- document developer account setup

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bda8eeec83288aac24fbf11807bd