### PR TITLE
Fix role-based redirects

### DIFF
--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -11,6 +11,7 @@ import AuthSignupForm from './components/AuthSignupForm';
 import AuthDemoOptions from './components/AuthDemoOptions';
 import AuthLoadingScreen from './components/AuthLoadingScreen';
 import { logger } from '@/utils/logger';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 const AuthPage = () => {
   const {
     user,
@@ -58,7 +59,7 @@ const AuthPage = () => {
     if (isNewUser && !showOnboarding) {
       setShowOnboarding(true);
     }
-    const redirectPath = profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+    const redirectPath = getDashboardUrl(profile);
     const from = location.state?.from?.pathname || redirectPath;
     logger.info("AuthPage: Redirecting to:", from);
     return <Navigate to={from} replace />;
@@ -68,7 +69,7 @@ const AuthPage = () => {
   if (isDemoMode() && !user) {
     const demoRole = localStorage.getItem('demoRole') as Role | null;
     if (demoRole) {
-      const redirectPath = demoRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: demoRole });
       logger.info("AuthPage: Demo mode active, redirecting to", redirectPath);
       return <Navigate to={redirectPath} replace />;
     }
@@ -82,7 +83,7 @@ const AuthPage = () => {
     setIsTransitioning(true);
     // Simulate loading and transition to dashboard
     setTimeout(() => {
-      const redirectPath = selectedRole === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+      const redirectPath = getDashboardUrl({ role: selectedRole });
       logger.info("AuthPage: Transitioning to", redirectPath);
       navigate(redirectPath, {
         replace: true

--- a/src/pages/onboarding/OnboardingPage.tsx
+++ b/src/pages/onboarding/OnboardingPage.tsx
@@ -16,6 +16,7 @@ import OnboardingProgress from './components/OnboardingProgress';
 import StepNavigation from './components/StepNavigation';
 import StepIndicator from './components/StepIndicator';
 import AIAssistantHelper from '@/components/AIAssistant/AIAssistantHelper';
+import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 
 // Define the tour steps for the guided tutorial
 const DASHBOARD_TOUR_STEPS = [
@@ -71,7 +72,7 @@ const OnboardingPage: React.FC = () => {
         
         // If onboarding is already complete, redirect to dashboard
         if (data?.onboarding_completed_at) {
-          const redirectPath = profile.role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
+          const redirectPath = getDashboardUrl({ role: profile.role });
           navigate(redirectPath);
         }
       } catch (err) {
@@ -122,7 +123,7 @@ const OnboardingPage: React.FC = () => {
       // After a delay, redirect to the appropriate dashboard
       setTimeout(() => {
         toast.success('Onboarding complete! Welcome to your SalesOS.');
-        navigate('/manager/dashboard');
+        navigate(getDashboardUrl({ role: profile.role }));
       }, 3000);
       
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- ensure AuthPage uses `getDashboardUrl` instead of role checks
- redirect from onboarding via `getDashboardUrl`
- keep `getDashboardUrl` returning `/developer/dashboard`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846c7f30e848328b7096697795d2e7a