### PR TITLE
Document developer demo login restriction

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ run:
 npm run create:developer
 ```
 
+Quick demo login is only available for Manager and Sales Rep roles. Developers
+should sign in using the credentials created by this script.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -6,6 +6,7 @@ import { Role } from '@/contexts/auth/types';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 
 interface AuthDemoOptionsProps {
   selectedRole: Role;
@@ -78,7 +79,7 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
           Fill in Demo Credentials
         </Button>
         
-        {selectedRole !== 'developer' && (
+        {selectedRole !== 'developer' ? (
           <Button
             onClick={handleDirectDemoLogin}
             variant="default"
@@ -86,6 +87,21 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
           >
             Quick Demo Login
           </Button>
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="default"
+                disabled
+                className="w-full py-2 bg-salesBlue text-sm font-medium opacity-50 cursor-not-allowed"
+              >
+                Quick Demo Login
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Developer quick demo login is not available</p>
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
 
@@ -93,7 +109,7 @@ const AuthDemoOptions: React.FC<AuthDemoOptionsProps> = ({
         {selectedRole === 'manager'
           ? 'Demo Manager Account'
           : selectedRole === 'developer'
-          ? 'Use developer credentials to log in'
+          ? 'Developer quick demo login unavailable. Use your credentials.'
           : 'Demo Sales Rep Account'}
       </p>
     </div>


### PR DESCRIPTION
## Summary
- add a tooltip and message noting that quick demo login isn't available for developers
- mention the limitation in the README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846c7f519888328894bb6fce71c3ffd