### PR TITLE
Fix typo in landing page hero section

### DIFF
--- a/src/pages/NewLandingPage.tsx
+++ b/src/pages/NewLandingPage.tsx
@@ -222,7 +222,7 @@ const NewLandingPage: React.FC = () => {
               <h2 className="text-4xl md:text-5xl font-bold text-slate-900 mb-6">
                 Designed to Feel Like <span className="text-purple-600">Magic</span>
               </h2>
-              <p className="text-xl text-slate-600 max-w-3xl mx-auto">TSAM doesn't just log tasks. It thinks, adapts, and guides. From first touch to close, your AI operating sysyem handles it or coaches your team to do it better.</p>
+              <p className="text-xl text-slate-600 max-w-3xl mx-auto">TSAM doesn't just log tasks. It thinks, adapts, and guides. From first touch to close, your AI operating system handles it or coaches your team to do it better.</p>
             </div>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">


### PR DESCRIPTION
## Summary
- correct minor typo in the hero description text on the new landing page

## Testing
- `npx vitest` *(fails: Need to install the following packages)*

------
https://chatgpt.com/codex/tasks/task_e_6846cfea29488328853475e9f48cdef9