### PR TITLE
Improve auth login/logout experience with unified loaders

### DIFF
--- a/src/components/Dashboard/DashboardHeader.tsx
+++ b/src/components/Dashboard/DashboardHeader.tsx
@@ -74,7 +74,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
                 localStorage.removeItem('demoMode');
                 localStorage.removeItem('demoRole');
                 localStorage.removeItem('planType');
-                window.location.href = '/auth';
+                window.location.href = '/logout';
               }}
             >
               Exit Demo

--- a/src/components/Manager/ManagerOverviewCards.tsx
+++ b/src/components/Manager/ManagerOverviewCards.tsx
@@ -34,7 +34,7 @@ const ManagerOverviewCards: React.FC<ManagerOverviewCardsProps> = ({
             onClick={() => {
               localStorage.removeItem('demoMode');
               localStorage.removeItem('demoRole');
-              window.location.href = '/auth';
+              window.location.href = '/logout';
             }}
           >
             Exit Demo

--- a/src/components/Navigation/DeveloperNavigation.tsx
+++ b/src/components/Navigation/DeveloperNavigation.tsx
@@ -1,7 +1,7 @@
 import { logger } from '@/utils/logger';
 
 import React, { useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { 
@@ -24,7 +24,8 @@ import { useAuth } from '@/contexts/AuthContext';
 
 const DeveloperNavigation: React.FC = () => {
   const location = useLocation();
-  const { profile, signOut } = useAuth();
+  const { profile } = useAuth();
+  const navigate = useNavigate();
   const [testMode, setTestMode] = useState('developer');
 
   const navItems = [
@@ -50,12 +51,8 @@ const DeveloperNavigation: React.FC = () => {
     logger.info(`Developer Testing: Simulating ${nextMode} experience`);
   };
 
-  const handleLogout = async () => {
-    try {
-      await signOut();
-    } catch (error) {
-      logger.error('Logout failed:', error);
-    }
+  const handleLogout = () => {
+    navigate('/logout');
   };
 
   return (

--- a/src/components/Navigation/RoleToggle.tsx
+++ b/src/components/Navigation/RoleToggle.tsx
@@ -7,7 +7,7 @@ import { useAuth } from '@/contexts/AuthContext';
 
 const RoleToggle = () => {
   const navigate = useNavigate();
-  const { profile, signOut } = useAuth();
+  const { profile } = useAuth();
 
   const currentRole = profile?.role || 'sales_rep';
   
@@ -17,11 +17,9 @@ const RoleToggle = () => {
   
   if (!isDev && !isOnDeveloperRoute) return null;
 
-  const handleRoleSwitch = async () => {
-    // For proper role switching, user must log out and log back in
-    // This ensures clean state and proper routing
-    await signOut();
-    navigate('/auth');
+  const handleRoleSwitch = () => {
+    // Redirect to logout page to switch roles cleanly
+    navigate('/logout');
   };
 
   return (

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { LogOut, Settings, User } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
 
 export interface UserProfileProps {
   name: string;
@@ -22,17 +21,11 @@ export interface UserProfileProps {
 }
 
 const UserProfile: React.FC<UserProfileProps> = ({ name, role }) => {
-  const { user, signOut } = useAuth();
   const navigate = useNavigate();
 
-  const handleLogout = async () => {
-    try {
-      logger.info('Logout requested');
-      await signOut();
-      window.location.href = '/auth';
-    } catch (error) {
-      logger.error('Logout failed:', error);
-    }
+  const handleLogout = () => {
+    logger.info('Logout requested');
+    navigate('/logout');
   };
 
   const initials = name.split(' ').map(n => n[0]).join('').toUpperCase();

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -79,11 +79,12 @@ const AuthPage = () => {
     setSelectedRole(role);
     setLastSelectedRole(role);
   };
-  const simulateLoginTransition = () => {
+  const simulateLoginTransition = (roleParam?: Role) => {
     setIsTransitioning(true);
     // Simulate loading and transition to dashboard
     setTimeout(() => {
-      const redirectPath = getDashboardUrl({ role: selectedRole });
+      const roleToUse = roleParam || selectedRole;
+      const redirectPath = getDashboardUrl({ role: roleToUse });
       logger.info("AuthPage: Transitioning to", redirectPath);
       navigate(redirectPath, {
         replace: true

--- a/src/pages/auth/components/AuthDemoOptions.tsx
+++ b/src/pages/auth/components/AuthDemoOptions.tsx
@@ -11,7 +11,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip
 interface AuthDemoOptionsProps {
   selectedRole: Role;
   setIsTransitioning: (value: boolean) => void;
-  simulateLoginTransition: () => void;
+  simulateLoginTransition: (role?: Role) => void;
   setFormData: (data: { email: string; password: string }) => void;
 }
 

--- a/src/pages/auth/components/AuthLoginForm.tsx
+++ b/src/pages/auth/components/AuthLoginForm.tsx
@@ -6,13 +6,11 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { LogIn } from 'lucide-react';
 import { toast } from 'sonner';
-import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
-import { getDashboardUrl } from '@/components/Navigation/navigationUtils';
 import { Role } from '@/contexts/auth/types';
 interface AuthLoginFormProps {
   setIsTransitioning: (value: boolean) => void;
-  simulateLoginTransition: () => void;
+  simulateLoginTransition: (role?: Role) => void;
   formData?: {
     email: string;
     password: string;
@@ -33,7 +31,6 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
   const {
     signIn
   } = useAuth();
-  const navigate = useNavigate();
   const [internalFormData, setInternalFormData] = useState({
     email: 'sales.rep@company.com',
     password: 'fulluser123'
@@ -79,12 +76,12 @@ const AuthLoginForm: React.FC<AuthLoginFormProps> = ({
       if (profileError || !profileData) {
         throw profileError || new Error('Profile not found');
       }
-      navigate(getDashboardUrl({
-        role: profileData.role
-      }));
+
+      simulateLoginTransition(profileData.role as Role);
     } catch (error: any) {
       logger.error('Authentication error:', error);
       toast.error(error.message || 'Login failed');
+      setIsTransitioning(false);
     } finally {
       setIsLoading(false);
     }


### PR DESCRIPTION
## Summary
- show full-page loader during login transition
- route all logout actions through dedicated logout page
- update demo exit buttons to use logout route

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6846d8322af483289ca2970ca6d8d793