### PR TITLE
Fix auth redirects with navigate

### DIFF
--- a/src/components/LogoutHandler.tsx
+++ b/src/components/LogoutHandler.tsx
@@ -1,10 +1,12 @@
 import { logger } from '@/utils/logger';
 
 import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 
 const LogoutHandler = () => {
   const { signOut } = useAuth();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const handleLogout = async () => {
@@ -29,20 +31,20 @@ const LogoutHandler = () => {
         
         logger.info('LogoutHandler: Forcing redirect to auth');
         
-        // Force a complete page reload to the auth page to clear all state
-        window.location.replace('/auth');
+        // Navigate to auth without full page reload
+        setTimeout(() => navigate('/auth', { replace: true }), 100);
         
       } catch (error) {
         logger.error('LogoutHandler error:', error);
         // Force redirect even on error
         localStorage.clear();
         sessionStorage.clear();
-        window.location.replace('/auth');
+        setTimeout(() => navigate('/auth', { replace: true }), 100);
       }
     };
 
     handleLogout();
-  }, [signOut]);
+  }, [signOut, navigate]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-slate-50">

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -38,9 +38,7 @@ const RequireAuth: React.FC<RequireAuthProps> = ({ children }) => {
   // If no user and not in demo mode, redirect to auth
   if (!user) {
     logger.info('RequireAuth: No user, redirecting to auth');
-    // Force a complete redirect to clear any cached state
-    window.location.replace('/auth');
-    return null;
+    return <Navigate to="/auth" replace />;
   }
 
   // If user is authenticated but no profile, redirect to auth for completion


### PR DESCRIPTION
## Summary
- use `useNavigate` inside `LogoutHandler` and `RequireAuth`
- replace `window.location.replace` with client-side redirects

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846db38beb88328806ad008c6226023