### PR TITLE
Add demo sign-up fallback

### DIFF
--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -185,6 +185,21 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const signUp = async (email: string, password: string, metadata?: any): Promise<{ error?: AuthError }> => {
     try {
       setLoading(true);
+
+      // If Supabase isn't configured, fall back to local demo mode
+      if (!isSupabaseConfigured) {
+        const role: Role = metadata?.role ?? (email.includes('manager') ? 'manager' : 'sales_rep');
+        const { demoUser, demoProfile } = initializeDemoUser(role);
+        localStorage.setItem('demoMode', 'true');
+        localStorage.setItem('demoRole', role);
+        setLastSelectedRole(role);
+        setUser(demoUser);
+        setProfile(demoProfile);
+        setSession(null);
+        toast.success('Demo account created successfully');
+        return {};
+      }
+
       const { error } = await supabase.auth.signUp({
         email,
         password,


### PR DESCRIPTION
## Summary
- support demo sign up when Supabase isn't configured

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6846ddf8020c83288c7296002cecc235