### PR TITLE
Fix signup flow and role-based routing

### DIFF
--- a/src/__tests__/routing.test.tsx
+++ b/src/__tests__/routing.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react'
 import { describe, it, expect, vi, afterEach, beforeEach, beforeAll } from 'vitest'
 import { JSDOM } from 'jsdom'
 import { AuthProvider, useAuth } from '@/contexts/auth/AuthContext'
+import { MemoryRouter } from 'react-router-dom'
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
@@ -59,7 +60,9 @@ describe('signOut routing', () => {
     sessionStorage.setItem('baz', 'qux')
 
     const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <AuthProvider>{children}</AuthProvider>
+      <MemoryRouter>
+        <AuthProvider>{children}</AuthProvider>
+      </MemoryRouter>
     )
     const { result } = renderHook(() => useAuth(), { wrapper })
 

--- a/src/contexts/auth/AuthContext.tsx
+++ b/src/contexts/auth/AuthContext.tsx
@@ -194,7 +194,12 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setLoading(true);
       
       const { data, error } = await supabase.auth.signUp({
-      const { data, error } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: metadata
+        }
+      });
 
       // If Supabase isn't configured, fall back to local demo mode
       if (!isSupabaseConfigured) {
@@ -209,14 +214,6 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         toast.success('Demo account created successfully');
         return {};
       }
-
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          data: metadata,
-        },
-      });
 
       if (error) {
         toast.error(error.message);
@@ -277,6 +274,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         } else {
           logger.error('Error fetching profile after sign up:', profileError);
           toast.error('Company setup failed: ' + profileError.message);
+        }
+      }
+
       const session = data.session;
       const newUser = data.user;
 

--- a/src/pages/auth/components/AuthSignupForm.tsx
+++ b/src/pages/auth/components/AuthSignupForm.tsx
@@ -26,6 +26,11 @@ const AuthSignupForm: React.FC<AuthSignupFormProps> = ({
   } = useAuth();
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailPattern.test(email)) {
+      toast.error('Please enter a valid email address');
+      return;
+    }
     if (password !== confirmPassword) {
       toast.error('Passwords do not match');
       return;
@@ -41,6 +46,7 @@ const AuthSignupForm: React.FC<AuthSignupFormProps> = ({
         toast.error(error.message);
       } else {
         toast.success('Account created successfully! Please check your email.');
+        if (setIsLogin) setIsLogin(true);
       }
     } catch (error) {
       toast.error('An unexpected error occurred');


### PR DESCRIPTION
## Summary
- validate email on the sign-up form and show an error if invalid
- switch to login view after successful sign up
- correct sign-up logic in AuthContext
- wrap routing unit test with `MemoryRouter`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e504c1d08328a42ade07dfbbb128