### PR TITLE
Implement MockAuthProvider in developer page tests

### DIFF
--- a/tests/developerPagesResponsive.test.tsx
+++ b/tests/developerPagesResponsive.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react'
+import React, { createContext, useContext } from 'react'
 import { render, screen } from '@testing-library/react'
-import { describe, it, beforeEach, expect } from 'vitest'
+import { describe, it, beforeEach, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
+import type { AuthContextType, Profile } from '@/contexts/auth/types'
 
 import AIBrainLogs from '../src/pages/developer/AIBrainLogs'
 import APILogs from '../src/pages/developer/APILogs'
@@ -14,6 +15,40 @@ import Settings from '../src/pages/developer/Settings'
 import SystemMonitor from '../src/pages/developer/SystemMonitor'
 import TestingSandbox from '../src/pages/developer/TestingSandbox'
 import VersionControl from '../src/pages/developer/VersionControl'
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+const MockAuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const value: AuthContextType = {
+    user: null,
+    profile: { id: '1', role: 'developer' } as Profile,
+    session: null,
+    loading: false,
+    signIn: async () => ({}),
+    signUp: async () => ({}),
+    signUpWithOAuth: async () => ({}),
+    signOut: async () => {},
+    fetchProfile: async () => null,
+    isDemoMode: () => false,
+    setLastSelectedRole: () => {},
+    getLastSelectedRole: () => 'developer',
+    setLastSelectedCompanyId: () => {},
+    getLastSelectedCompanyId: () => null,
+    initializeDemoMode: () => {}
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+function useMockAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within an AuthProvider')
+  return ctx
+}
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: useMockAuth
+}))
 
 const pages = [
   { component: AIBrainLogs, title: 'AI Brain Logs' },
@@ -37,7 +72,11 @@ describe('developer pages small viewport render', () => {
 
   pages.forEach(({ component: Component, title }) => {
     it(`renders ${title}`, () => {
-      render(<Component />)
+      render(
+        <MockAuthProvider>
+          <Component />
+        </MockAuthProvider>
+      )
       expect(screen.getAllByText(title).length).toBeGreaterThan(0)
     })
   })


### PR DESCRIPTION
## Summary
- create a minimal `MockAuthProvider` for developer page tests
- mock `useAuth` in `tests/developerPagesResponsive.test.tsx`
- wrap each developer page render with the mock provider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68491b17ff6c8328a85f5dba67c5f31e