### PR TITLE
Fix OS navigation routing

### DIFF
--- a/src/components/Navigation/DeveloperNavigation.tsx
+++ b/src/components/Navigation/DeveloperNavigation.tsx
@@ -15,14 +15,19 @@ const DeveloperNavigation: React.FC = () => {
 
   const navItems = [
     { href: '/developer/dashboard', label: 'Dashboard', icon: LayoutDashboard },
-    { href: '/developer/agents', label: 'Agent Management', icon: Brain },
-    { href: '/developer/database', label: 'Database', icon: Database },
-    { href: '/developer/monitoring', label: 'Monitoring', icon: Activity },
+    { href: '/developer/system-monitor', label: 'System Monitor', icon: Activity },
+    { href: '/developer/ai-brain-logs', label: 'AI Logs', icon: Brain },
+    { href: '/developer/api-logs', label: 'API Logs', icon: Database },
+    { href: '/developer/error-logs', label: 'Error Logs', icon: Activity },
+    { href: '/developer/qa-checklist', label: 'QA Checklist', icon: Activity },
+    { href: '/developer/testing-sandbox', label: 'Testing Sandbox', icon: Activity },
+    { href: '/developer/version-control', label: 'Version Control', icon: Activity },
+    { href: '/developer/crm-integrations', label: 'CRM Integrations', icon: Database },
     { href: '/developer/settings', label: 'Settings', icon: Settings },
   ];
 
   return (
-    <nav className="flex items-center gap-4 p-4 bg-white border-b">
+    <nav className="flex items-center gap-4 p-4 bg-slate-800 text-white border-b border-slate-700">
       {navItems.map((item) => {
         const Icon = item.icon;
         const isActive = location.pathname === item.href;

--- a/src/layouts/ManagerOS.tsx
+++ b/src/layouts/ManagerOS.tsx
@@ -9,6 +9,10 @@ import ManagerAnalytics from '@/pages/manager/Analytics';
 import ManagerLeadManagement from '@/pages/manager/LeadManagement';
 import ManagerCompanyBrain from '@/pages/manager/CompanyBrain';
 import ManagerAI from '@/pages/manager/AI';
+import ManagerCRMIntegrations from '@/pages/manager/CRMIntegrations';
+import TeamManagement from '@/pages/manager/TeamManagement';
+import SecurityPage from '@/pages/manager/Security';
+import Reports from '@/pages/manager/Reports';
 import ManagerSettings from '@/pages/manager/Settings';
 
 const ManagerOS: React.FC = () => {
@@ -20,9 +24,13 @@ const ManagerOS: React.FC = () => {
           <Route index element={<ManagerDashboard />} />
           <Route path="dashboard" element={<ManagerDashboard />} />
           <Route path="analytics" element={<ManagerAnalytics />} />
-          <Route path="leads" element={<ManagerLeadManagement />} />
+          <Route path="lead-management" element={<ManagerLeadManagement />} />
           <Route path="company-brain" element={<ManagerCompanyBrain />} />
           <Route path="ai" element={<ManagerAI />} />
+          <Route path="crm-integrations" element={<ManagerCRMIntegrations />} />
+          <Route path="team-management" element={<TeamManagement />} />
+          <Route path="security" element={<SecurityPage />} />
+          <Route path="reports" element={<Reports />} />
           <Route path="settings" element={<ManagerSettings />} />
           <Route path="*" element={<Navigate to="/manager/dashboard" replace />} />
         </Routes>

--- a/src/layouts/SalesRepOS.tsx
+++ b/src/layouts/SalesRepOS.tsx
@@ -20,7 +20,7 @@ const SalesRepOS: React.FC = () => {
           <Route index element={<SalesRepDashboard />} />
           <Route path="dashboard" element={<SalesRepDashboard />} />
           <Route path="analytics" element={<SalesRepAnalytics />} />
-          <Route path="leads" element={<SalesRepLeadManagement />} />
+          <Route path="lead-management" element={<SalesRepLeadManagement />} />
           <Route path="academy" element={<SalesRepAcademy />} />
           <Route path="ai" element={<SalesRepAI />} />
           <Route path="settings" element={<SalesRepSettings />} />


### PR DESCRIPTION
## Summary
- fix SalesRepOS route for lead management
- align ManagerOS routes with navigation
- update DeveloperNavigation to list all developer pages and use dark theme

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*

------
https://chatgpt.com/codex/tasks/task_e_684a5b8d9bbc8328b3d1047fb59b49d8