### PR TITLE
Fix auth routing and logout flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Toaster } from 'sonner';
 import { ThemeProvider } from 'next-themes';
@@ -11,6 +11,7 @@ import { UnifiedAIProvider } from '@/contexts/UnifiedAIContext';
 import RequireAuth from '@/components/RequireAuth';
 import LandingPage from '@/pages/LandingPage';
 import AuthPage from '@/pages/auth/AuthPage';
+import Logout from '@/pages/auth/Logout';
 import LoginPage from '@/pages/LoginPage';
 import SignupPage from '@/pages/SignupPage';
 
@@ -61,8 +62,9 @@ function App() {
                       {/* Public routes */}
                       <Route path="/" element={<LandingPage />} />
                       <Route path="/auth" element={<AuthPage />} />
-                      <Route path="/login" element={<LoginPage />} />
-                      <Route path="/signup" element={<SignupPage />} />
+                      <Route path="/logout" element={<Logout />} />
+                      <Route path="/login" element={<Navigate to="/auth" replace />} />
+                      <Route path="/signup" element={<Navigate to="/auth" replace />} />
 
                       {/* Protected routes */}
                       <Route

--- a/tests/developerPagesResponsive.test.tsx
+++ b/tests/developerPagesResponsive.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { describe, it, beforeEach, expect } from 'vitest'
+import { describe, it, beforeEach, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 
 import AIBrainLogs from '../src/pages/developer/AIBrainLogs'
@@ -14,6 +14,11 @@ import Settings from '../src/pages/developer/Settings'
 import SystemMonitor from '../src/pages/developer/SystemMonitor'
 import TestingSandbox from '../src/pages/developer/TestingSandbox'
 import VersionControl from '../src/pages/developer/VersionControl'
+
+// Mock AuthContext to avoid needing full provider setup
+vi.mock('../src/contexts/AuthContext', () => ({
+  useAuth: () => ({ profile: { role: 'developer' } })
+}))
 
 const pages = [
   { component: AIBrainLogs, title: 'AI Brain Logs' },


### PR DESCRIPTION
## Summary
- map `/login` and `/signup` routes to `/auth`
- add missing `/logout` route
- update tests to mock auth context so components render

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684a7260c40c8328a6e45463b818f84d