### PR TITLE
Add global 404 route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import AuthPage from '@/pages/auth/AuthPage';
 import Logout from '@/pages/auth/Logout';
 import LoginPage from '@/pages/LoginPage';
 import SignupPage from '@/pages/SignupPage';
+import NotFound from '@/pages/NotFound';
 
 // Layout imports
 import SalesLayout from '@/layouts/SalesLayout';
@@ -91,6 +92,7 @@ function App() {
                           </RequireAuth>
                         }
                       />
+                      <Route path="*" element={<NotFound />} />
                     </Routes>
 
                     <Toaster


### PR DESCRIPTION
## Summary
- import NotFound page in App
- add catch-all route to render NotFound page

## Testing
- `npm test` *(fails: vitest not installed)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npx tsc --noEmit` *(fails: tsc missing)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a998db520832888f719ed843bb56c