### PR TITLE
Fix routing stability with error boundaries

### DIFF
--- a/src/layouts/DeveloperLayout.tsx
+++ b/src/layouts/DeveloperLayout.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import { Routes, Route, NavLink } from 'react-router-dom';
 import { 
   Settings, 
@@ -55,9 +56,10 @@ const DeveloperLayout: React.FC = () => {
 
         {/* Main content */}
         <div className="flex-1 bg-slate-50 dark:bg-slate-900">
-          <Routes>
-            <Route index element={<AgentHealthDashboard />} />
-            <Route path="advanced" element={<AdvancedFeatures />} />
+          <ErrorBoundary fallback={<div className="p-4">Something went wrong. Please refresh or contact support.</div>}>
+            <Routes>
+              <Route index element={<AgentHealthDashboard />} />
+              <Route path="advanced" element={<AdvancedFeatures />} />
             <Route 
               path="api" 
               element={
@@ -68,10 +70,10 @@ const DeveloperLayout: React.FC = () => {
                     <p className="text-slate-600 dark:text-slate-400">Advanced API testing and management tools coming soon.</p>
                   </div>
                 </div>
-              } 
+              }
             />
-            <Route 
-              path="testing" 
+            <Route
+              path="testing"
               element={
                 <div className="p-6">
                   <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm p-8 text-center">
@@ -80,9 +82,10 @@ const DeveloperLayout: React.FC = () => {
                     <p className="text-slate-600 dark:text-slate-400">Comprehensive testing tools and automation coming soon.</p>
                   </div>
                 </div>
-              } 
+              }
             />
-          </Routes>
+            </Routes>
+          </ErrorBoundary>
         </div>
       </div>
     </div>

--- a/src/layouts/ManagerLayout.tsx
+++ b/src/layouts/ManagerLayout.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import ManagerNavigation from '@/components/Navigation/ManagerNavigation';
 
@@ -15,7 +15,9 @@ import SecurityPage from '@/pages/manager/Security';
 import Reports from '@/pages/manager/Reports';
 import ManagerSettings from '@/pages/manager/Settings';
 
-import UnifiedAIBubble from '@/components/UnifiedAI/UnifiedAIBubble';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
+
+const UnifiedAIBubble = lazy(() => import('@/components/UnifiedAI/UnifiedAIBubble'));
 import { useAIContext } from '@/contexts/AIContext';
 import { useLocation } from 'react-router-dom';
 
@@ -46,31 +48,35 @@ const ManagerLayout = () => {
     emailContext,
     smsContext
   };
-  
+
   return (
     <div className="min-h-screen bg-background relative">
       <ManagerNavigation />
-      
+
       <main className="pt-[60px]">
-        <Routes>
-          <Route index element={<Navigate to="dashboard" replace />} />
-          <Route path="dashboard" element={<ManagerDashboard />} />
-          <Route path="analytics" element={<ManagerAnalytics />} />
-          <Route path="lead-management" element={<ManagerLeadManagement />} />
-          <Route path="company-brain" element={<ManagerCompanyBrain />} />
-          <Route path="ai" element={<ManagerAI />} />
-          <Route path="crm-integrations" element={<ManagerCRMIntegrations />} />
-          <Route path="team-management" element={<TeamManagement />} />
-          <Route path="security" element={<SecurityPage />} />
-          <Route path="reports" element={<Reports />} />
-          <Route path="settings" element={<ManagerSettings />} />
-          <Route path="*" element={<Navigate to="dashboard" replace />} />
-        </Routes>
+        <ErrorBoundary fallback={<div className="p-4">Something went wrong. Please refresh or contact support.</div>}>
+          <Routes>
+            <Route index element={<Navigate to="dashboard" replace />} />
+            <Route path="dashboard" element={<ManagerDashboard />} />
+            <Route path="analytics" element={<ManagerAnalytics />} />
+            <Route path="lead-management" element={<ManagerLeadManagement />} />
+            <Route path="company-brain" element={<ManagerCompanyBrain />} />
+            <Route path="ai" element={<ManagerAI />} />
+            <Route path="crm-integrations" element={<ManagerCRMIntegrations />} />
+            <Route path="team-management" element={<TeamManagement />} />
+            <Route path="security" element={<SecurityPage />} />
+            <Route path="reports" element={<Reports />} />
+            <Route path="settings" element={<ManagerSettings />} />
+            <Route path="*" element={<Navigate to="dashboard" replace />} />
+          </Routes>
+        </ErrorBoundary>
       </main>
-      
+
       {/* Manager AI Assistant */}
       <div className="fixed bottom-6 right-6 z-[9999]">
-        <UnifiedAIBubble context={aiContext} />
+        <Suspense>
+          <UnifiedAIBubble context={aiContext} />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/layouts/SalesLayout.tsx
+++ b/src/layouts/SalesLayout.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import ResponsiveNavigation from '@/components/Navigation/ResponsiveNavigation';
 
@@ -13,7 +13,9 @@ import SalesSettings from '@/pages/sales/Settings';
 import SalesDialer from '@/pages/sales/Dialer';
 import LeadWorkspace from '@/pages/LeadWorkspace';
 
-import UnifiedAIBubble from '@/components/UnifiedAI/UnifiedAIBubble';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
+
+const UnifiedAIBubble = lazy(() => import('@/components/UnifiedAI/UnifiedAIBubble'));
 import { useAIContext } from '@/contexts/AIContext';
 import { useLocation } from 'react-router-dom';
 
@@ -51,29 +53,33 @@ const SalesLayout = () => {
     emailContext,
     smsContext
   };
-  
+
   return (
     <div className="min-h-screen bg-slate-50 relative">
       <ResponsiveNavigation />
-      
+
       <main className="pt-[60px]">
-        <Routes>
-          <Route index element={<Navigate to="dashboard" replace />} />
-          <Route path="dashboard" element={<SalesRepDashboard />} />
-          <Route path="analytics" element={<SalesAnalytics />} />
-          <Route path="lead-management" element={<SalesLeadManagement />} />
-          <Route path="lead-workspace/:id" element={<LeadWorkspace />} />
-          <Route path="dialer" element={<SalesDialer />} />
-          <Route path="academy" element={<SalesAcademy />} />
-          <Route path="ai" element={<SalesAI />} />
-          <Route path="settings" element={<SalesSettings />} />
-          <Route path="*" element={<Navigate to="dashboard" replace />} />
-        </Routes>
+        <ErrorBoundary fallback={<div className="p-4">Something went wrong. Please refresh or contact support.</div>}>
+          <Routes>
+            <Route index element={<Navigate to="dashboard" replace />} />
+            <Route path="dashboard" element={<SalesRepDashboard />} />
+            <Route path="analytics" element={<SalesAnalytics />} />
+            <Route path="lead-management" element={<SalesLeadManagement />} />
+            <Route path="lead-workspace/:id" element={<LeadWorkspace />} />
+            <Route path="dialer" element={<SalesDialer />} />
+            <Route path="academy" element={<SalesAcademy />} />
+            <Route path="ai" element={<SalesAI />} />
+            <Route path="settings" element={<SalesSettings />} />
+            <Route path="*" element={<Navigate to="dashboard" replace />} />
+          </Routes>
+        </ErrorBoundary>
       </main>
-      
+
       {/* Unified AI Bubble - Single AI assistant with fixed positioning */}
       <div className="fixed bottom-6 right-6 z-[9999]">
-        <UnifiedAIBubble context={aiContext} />
+        <Suspense>
+          <UnifiedAIBubble context={aiContext} />
+        </Suspense>
       </div>
     </div>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { logger } from '@/utils/logger';
 import { setupAPIInterceptors } from './utils/apiInterceptor';
 
 import React from 'react';
+import ErrorBoundary from '@/components/common/ErrorBoundary';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
@@ -98,29 +99,37 @@ window.addEventListener('unhandledrejection', (event) => {
 try {
   root.render(
     <React.StrictMode>
-      <React.Suspense fallback={
-        <div style={{ 
-          display: 'flex', 
-          justifyContent: 'center', 
-          alignItems: 'center', 
-          minHeight: '100vh' 
-        }}>
-          <div style={{ textAlign: 'center' }}>
-            <div style={{ 
-              width: '40px', 
-              height: '40px', 
-              border: '4px solid #f3f4f6', 
-              borderTop: '4px solid #3b82f6', 
-              borderRadius: '50%', 
-              animation: 'spin 1s linear infinite',
-              margin: '0 auto 16px'
-            }}></div>
-            <p style={{ color: '#6b7280' }}>Loading application...</p>
-          </div>
-        </div>
-      }>
-        <App />
-      </React.Suspense>
+      <ErrorBoundary>
+        <React.Suspense
+          fallback={
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                minHeight: '100vh'
+              }}
+            >
+              <div style={{ textAlign: 'center' }}>
+                <div
+                  style={{
+                    width: '40px',
+                    height: '40px',
+                    border: '4px solid #f3f4f6',
+                    borderTop: '4px solid #3b82f6',
+                    borderRadius: '50%',
+                    animation: 'spin 1s linear infinite',
+                    margin: '0 auto 16px'
+                  }}
+                ></div>
+                <p style={{ color: '#6b7280' }}>Loading application...</p>
+              </div>
+            </div>
+          }
+        >
+          <App />
+        </React.Suspense>
+      </ErrorBoundary>
     </React.StrictMode>
   );
   logger.info('App rendered successfully');


### PR DESCRIPTION
## Summary
- add global ErrorBoundary wrapper in `main.tsx`
- lazy load AI widgets to avoid blocking render
- wrap app routes in ErrorBoundary for Sales, Manager and Developer layouts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9de3ce488328919a868b0f247308