### PR TITLE
Improve error handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import ManagerLayout from '@/layouts/ManagerLayout';
 import DeveloperLayout from '@/layouts/DeveloperLayout';
 import NotFound from '@/pages/NotFound';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
+import LoadingScreen from '@/components/common/LoadingScreen';
+import FullPageError from '@/components/common/FullPageError';
 import './App.css';
 
 const queryClient = new QueryClient({
@@ -36,12 +38,8 @@ function App() {
           <AIProvider>
             <Router>
               <div className="min-h-screen bg-background text-foreground">
-                <ErrorBoundary fallback={<div className="p-4">Something went wrong. Please refresh the page.</div>}>
-                  <Suspense fallback={
-                    <div className="min-h-screen flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-primary"></div>
-                    </div>
-                  }>
+                <ErrorBoundary fallback={<FullPageError />}>
+                  <Suspense fallback={<LoadingScreen />}>
                     <Routes>
                       {/* Public routes */}
                       <Route path="/" element={<LandingPage />} />

--- a/src/components/common/FullPageError.tsx
+++ b/src/components/common/FullPageError.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+const FullPageError: React.FC = () => (
+  <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-background">
+    <AlertTriangle className="w-12 h-12 text-destructive mb-4" />
+    <h1 className="text-xl font-semibold mb-2">Something went wrong</h1>
+    <p className="text-muted-foreground mb-4">Please refresh the page or try again later.</p>
+    <button
+      className="px-4 py-2 bg-primary text-primary-foreground rounded"
+      onClick={() => window.location.reload()}
+    >
+      Refresh Page
+    </button>
+  </div>
+);
+
+export default FullPageError;

--- a/src/components/common/LoadingScreen.tsx
+++ b/src/components/common/LoadingScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import LoadingSpinner from '@/components/LoadingSpinner';
+
+const LoadingScreen: React.FC = () => (
+  <div className="min-h-screen flex items-center justify-center">
+    <LoadingSpinner className="text-primary" size="lg" />
+  </div>
+);
+
+export default LoadingScreen;


### PR DESCRIPTION
## Summary
- add global `FullPageError` and `LoadingScreen` components
- use them inside `App.tsx` for root-level error boundary and suspense

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test --silent` *(fails: leadWorkspaceRoute and routing signOut tests)*

------
https://chatgpt.com/codex/tasks/task_e_684bab09e6c88328832ac98ad5e9a02d