### PR TITLE
Add advanced dashboard components

### DIFF
--- a/src/components/dashboard/AIAssistantHub.tsx
+++ b/src/components/dashboard/AIAssistantHub.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { AIAssistantStats } from '../../types/dashboard';
+
+interface AIAssistantHubProps {
+  stats: AIAssistantStats;
+}
+
+export const AIAssistantHub: React.FC<AIAssistantHubProps> = ({ stats }) => {
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">🤖 AI Assistant Summary</h3>
+        <span className="text-green-600 text-sm font-medium">Active</span>
+      </div>
+      
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <span className="mr-2">📧</span>
+            <span className="text-gray-600">Emails Drafted</span>
+          </div>
+          <span className="text-2xl font-bold text-blue-600">{stats.emailsDrafted}</span>
+        </div>
+        
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <span className="mr-2">📞</span>
+            <span className="text-gray-600">Calls Scheduled</span>
+          </div>
+          <span className="text-2xl font-bold text-green-600">{stats.callsScheduled}</span>
+        </div>
+        
+        <div className="flex items-center justify-between">
+          <div className="flex items-center">
+            <span className="mr-2">📋</span>
+            <span className="text-gray-600">Proposals Generated</span>
+          </div>
+          <span className="text-2xl font-bold text-purple-600">{stats.proposalsGenerated}</span>
+        </div>
+        
+        <div className="pt-3 border-t">
+          <div className="flex items-center justify-between">
+            <span className="text-gray-600">Performance Improvement</span>
+            <span className="text-green-600 font-semibold">+{stats.performanceImprovement}% ↗</span>
+          </div>
+          <p className="text-xs text-gray-500 mt-1">Compared to previous period</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/AIDailySummary.tsx
+++ b/src/components/dashboard/AIDailySummary.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+interface AIDailySummaryProps {
+  summary: string;
+}
+
+export const AIDailySummary: React.FC<AIDailySummaryProps> = ({ summary }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="bg-gradient-to-r from-blue-500 to-blue-600 text-white p-6 rounded-lg shadow-lg mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-lg font-semibold flex items-center">
+          <span className="mr-2">🤖</span>AI Daily Summary
+        </h3>
+        <span className="text-blue-200 text-sm">⚡ Live</span>
+      </div>
+      <p className="text-blue-100 mb-3">
+        {expanded ? summary + " Additional insights: Focus on Enterprise accounts between 2-4 PM for optimal response rates. Consider scheduling follow-ups for warm leads within 24 hours." : summary}
+      </p>
+      <button 
+        onClick={() => setExpanded(!expanded)}
+        className="text-blue-200 hover:text-white text-sm transition-colors"
+      >
+        {expanded ? 'Show less ▲' : 'Read more ▼'}
+      </button>
+    </div>
+  );
+};

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import Navigation from '@/components/Navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import StatsCard from '@/components/Dashboard/StatsCard';
+import {
+  Target,
+  Phone,
+  TrendingUp,
+  DollarSign,
+  CheckCircle
+} from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { AIDailySummary } from './AIDailySummary';
+import { AIAssistantHub } from './AIAssistantHub';
+import { SuggestedSchedule } from './SuggestedSchedule';
+import { PriorityTasks } from './PriorityTasks';
+import { PipelinePulse } from './PipelinePulse';
+import { useDashboardData } from '../../hooks/useDashboardData';
+
+const Dashboard: React.FC = () => {
+  const { profile } = useAuth();
+  const { data: dashboardData } = useDashboardData();
+
+  const mockStats = [
+    {
+      title: 'Active Leads',
+      value: '47',
+      change: '+12 this week',
+      changeType: 'positive' as const,
+      icon: Target,
+      iconColor: 'text-blue-600'
+    },
+    {
+      title: 'Calls Today',
+      value: '23',
+      change: '8 connected',
+      changeType: 'positive' as const,
+      icon: Phone,
+      iconColor: 'text-green-600'
+    },
+    {
+      title: 'Revenue Pipeline',
+      value: '$89K',
+      change: '+15% this month',
+      changeType: 'positive' as const,
+      icon: DollarSign,
+      iconColor: 'text-purple-600'
+    },
+    {
+      title: 'Conversion Rate',
+      value: '34%',
+      change: '+5% improvement',
+      changeType: 'positive' as const,
+      icon: TrendingUp,
+      iconColor: 'text-orange-600'
+    }
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col bg-slate-50">
+      <Navigation />
+      <div className="flex-1 p-6 space-y-8 max-w-7xl mx-auto">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Sales Dashboard</h1>
+            <p className="text-gray-600 mt-1">Welcome back, {profile?.full_name || 'Sales Rep'}</p>
+          </div>
+          <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+            <CheckCircle className="h-3 w-3 mr-1" />
+            AI Assistant Active
+          </Badge>
+        </div>
+
+        <AIDailySummary summary={dashboardData.aiSummary} />
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {mockStats.map((stat, index) => (
+            <StatsCard key={index} {...stat} />
+          ))}
+        </div>
+
+        <SuggestedSchedule schedule={dashboardData.suggestedSchedule} />
+
+        <PriorityTasks tasks={dashboardData.priorityTasks} />
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <span className="mr-2">🔄</span>Pipeline Pulse
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PipelinePulse leads={dashboardData.pipelineData} />
+            </CardContent>
+          </Card>
+          <AIAssistantHub stats={dashboardData.aiAssistant} />
+        </div>
+
+        <div className="text-center py-8">
+          <h2 className="text-xl font-semibold text-blue-600">🎯 Sales Rep OS Active</h2>
+          <p className="text-gray-600 mt-2">Your AI-powered sales dashboard is ready to accelerate your performance</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/components/dashboard/PipelinePulse.tsx
+++ b/src/components/dashboard/PipelinePulse.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { PipelineLead } from '../../types/dashboard';
+
+interface PipelinePulseProps {
+  leads: PipelineLead[];
+}
+
+export const PipelinePulse: React.FC<PipelinePulseProps> = ({ leads }) => {
+  const getStatusClasses = (status: string) => {
+    const statusMap = {
+      qualified: 'bg-green-100 text-green-700',
+      proposal: 'bg-blue-100 text-blue-700',
+      negotiation: 'bg-yellow-100 text-yellow-700',
+      closing: 'bg-purple-100 text-purple-700'
+    };
+    return statusMap[status as keyof typeof statusMap] || statusMap.qualified;
+  };
+
+  const getPriorityColor = (priority: string) => {
+    const priorityMap = {
+      high: 'bg-red-500',
+      medium: 'bg-yellow-500',
+      low: 'bg-green-500'
+    };
+    return priorityMap[priority as keyof typeof priorityMap] || priorityMap.medium;
+  };
+
+  const getAvatarColor = (avatar: string) => {
+    const colors = ['bg-blue-100 text-blue-600', 'bg-purple-100 text-purple-600', 'bg-green-100 text-green-600'];
+    return colors[avatar.charCodeAt(0) % colors.length];
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+          <span className="mr-2">🔄</span>Pipeline Pulse
+        </h3>
+        <button className="flex items-center text-blue-600 hover:text-blue-700 text-sm">
+          <span className="mr-1">🔍</span>Filter
+        </button>
+      </div>
+      
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b text-left text-sm text-gray-600">
+              <th className="pb-3">Lead</th>
+              <th className="pb-3">Status</th>
+              <th className="pb-3">Priority</th>
+              <th className="pb-3">Value</th>
+              <th className="pb-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="space-y-2">
+            {leads.map((lead) => (
+              <tr key={lead.id} className="border-b last:border-b-0">
+                <td className="py-3">
+                  <div className="flex items-center">
+                    <div className={`w-8 h-8 ${getAvatarColor(lead.avatar)} rounded-full flex items-center justify-center mr-3`}>
+                      <span className="font-medium text-sm">{lead.avatar}</span>
+                    </div>
+                    <div>
+                      <p className="font-medium text-gray-900">{lead.company}</p>
+                      <p className="text-sm text-gray-500">{lead.contact}</p>
+                    </div>
+                  </div>
+                </td>
+                <td className="py-3">
+                  <span className={`px-2 py-1 ${getStatusClasses(lead.status)} rounded-full text-xs`}>
+                    {lead.status}
+                  </span>
+                </td>
+                <td className="py-3">
+                  <span className={`w-3 h-3 ${getPriorityColor(lead.priority)} rounded-full inline-block`}></span>
+                </td>
+                <td className="py-3">
+                  <span className="font-semibold text-gray-900">{lead.value}</span>
+                </td>
+                <td className="py-3">
+                  <div className="flex space-x-2">
+                    <button className="p-1 hover:bg-gray-100 rounded">📞</button>
+                    <button className="p-1 hover:bg-gray-100 rounded">📧</button>
+                    <button className="p-1 hover:bg-gray-100 rounded">📅</button>
+                    <button className="p-1 hover:bg-gray-100 rounded">📋</button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/PriorityTasks.tsx
+++ b/src/components/dashboard/PriorityTasks.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { PriorityTask } from '../../types/dashboard';
+
+interface PriorityTasksProps {
+  tasks: PriorityTask[];
+}
+
+export const PriorityTasks: React.FC<PriorityTasksProps> = ({ tasks }) => {
+  const getPriorityClasses = (priority: string) => {
+    const priorityMap = {
+      high: 'border-red-500 bg-red-50 bg-red-100 text-red-700',
+      medium: 'border-yellow-500 bg-yellow-50 bg-yellow-100 text-yellow-700',
+      low: 'border-green-500 bg-green-50 bg-green-100 text-green-700'
+    };
+    return priorityMap[priority as keyof typeof priorityMap] || priorityMap.medium;
+  };
+
+  const getTaskIcon = (type: string) => {
+    const iconMap = {
+      call: '📞',
+      email: '📧',
+      meeting: '🤝',
+      proposal: '📋'
+    };
+    return iconMap[type as keyof typeof iconMap] || '📋';
+  };
+
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+          <span className="mr-2">⚡</span>Suggested Tasks
+        </h3>
+        <button className="text-blue-600 hover:text-blue-700 text-sm">View All</button>
+      </div>
+      
+      <div className="space-y-3">
+        {tasks.map((task) => {
+          const priorityClasses = getPriorityClasses(task.priority);
+          const [borderClass, bgClass, badgeBg, badgeText] = priorityClasses.split(' ');
+          
+          return (
+            <div key={task.id} className={`flex items-center justify-between p-4 border-l-4 ${borderClass} ${bgClass} rounded-r-lg`}>
+              <div className="flex-1">
+                <div className="flex items-center mb-1">
+                  <span className="mr-2">{getTaskIcon(task.type)}</span>
+                  <span className="font-medium text-gray-900">{task.title}</span>
+                </div>
+                <div className="flex items-center text-sm text-gray-600">
+                  <span className={`px-2 py-1 ${badgeBg} ${badgeText} rounded text-xs mr-2`}>
+                    {task.priority} priority
+                  </span>
+                  <span>Suggested: {task.suggestedTime}</span>
+                </div>
+                <p className="text-xs text-gray-500 mt-1">{task.description}</p>
+              </div>
+              <button className="ml-4 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-sm font-medium">
+                Start
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/components/dashboard/SuggestedSchedule.tsx
+++ b/src/components/dashboard/SuggestedSchedule.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { ScheduleItem } from '../../types/dashboard';
+
+interface SuggestedScheduleProps {
+  schedule: ScheduleItem[];
+}
+
+export const SuggestedSchedule: React.FC<SuggestedScheduleProps> = ({ schedule }) => {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const totalDuration = schedule.reduce((total, item) => {
+    const duration = parseFloat(item.duration);
+    return total + (isNaN(duration) ? 0 : duration);
+  }, 0);
+
+  const getColorClasses = (color: string) => {
+    const colorMap = {
+      blue: 'text-blue-600 bg-blue-500',
+      green: 'text-green-600 bg-green-500',
+      orange: 'text-orange-600 bg-orange-500'
+    };
+    return colorMap[color as keyof typeof colorMap] || 'text-blue-600 bg-blue-500';
+  };
+
+  return (
+    <div className="bg-blue-50 p-6 rounded-lg shadow-sm mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-gray-900 flex items-center">
+          <span className="mr-2">📅</span>Suggested Schedule
+        </h3>
+        <div className="flex items-center space-x-3">
+          <span className="text-blue-600 text-sm font-medium">{totalDuration}h total</span>
+          <button 
+            onClick={() => setCollapsed(!collapsed)}
+            className="text-blue-600 hover:text-blue-700 text-sm"
+          >
+            {collapsed ? 'Show ▼' : 'Hide ▲'}
+          </button>
+        </div>
+      </div>
+      
+      {!collapsed && (
+        <div className="space-y-3">
+          {schedule.map((item) => {
+            const colorClasses = getColorClasses(item.color);
+            return (
+              <div key={item.id} className="flex items-center justify-between p-3 bg-white rounded-lg">
+                <div className="flex items-center">
+                  <span className={`mr-3 ${colorClasses.split(' ')[0]}`}>🕘 {item.time}</span>
+                  <div>
+                    <span className="font-medium text-gray-900">{item.title}</span>
+                    <div className="flex items-center mt-1">
+                      <span className={`w-2 h-2 ${colorClasses.split(' ')[1]} rounded-full mr-2`}></span>
+                      <span className="text-sm text-gray-600">{item.description}</span>
+                    </div>
+                  </div>
+                </div>
+                <span className="text-gray-500 text-sm">{item.duration}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      
+      <p className="text-xs text-blue-600 mt-3 flex items-center">
+        <span className="mr-1">💡</span>
+        Suggested based on your activity patterns and optimal contact times
+      </p>
+    </div>
+  );
+};

--- a/src/hooks/useDashboardData.ts
+++ b/src/hooks/useDashboardData.ts
@@ -1,0 +1,101 @@
+import { useState, useEffect } from 'react';
+import { DashboardData } from '../types/dashboard';
+
+export const useDashboardData = () => {
+  const [data, setData] = useState<DashboardData>({
+    aiSummary: "Good morning! You have 12 high-priority leads requiring immediate attention. Your conversion rate improved by 23% this week. AI suggests focusing on Enterprise leads today.",
+    aiAssistant: {
+      emailsDrafted: 23,
+      callsScheduled: 12,
+      proposalsGenerated: 5,
+      performanceImprovement: 34
+    },
+    suggestedSchedule: [
+      {
+        id: '1',
+        time: '09:00',
+        title: 'Priority Lead Calls',
+        description: 'High impact activities',
+        duration: '2h',
+        priority: 'high',
+        color: 'blue'
+      },
+      {
+        id: '2',
+        time: '11:30',
+        title: 'Follow-up Emails',
+        description: 'Nurture warm leads',
+        duration: '30m',
+        priority: 'medium',
+        color: 'green'
+      },
+      {
+        id: '3',
+        time: '14:00',
+        title: 'Warm Lead Outreach',
+        description: 'Peak response time',
+        duration: '1.5h',
+        priority: 'medium',
+        color: 'orange'
+      }
+    ],
+    priorityTasks: [
+      {
+        id: '1',
+        type: 'call',
+        title: 'Call Maria Rodriguez at TechCorp',
+        description: 'Warm lead ready to close - $125K potential',
+        suggestedTime: '2:30 PM',
+        priority: 'high',
+        value: '$125K'
+      },
+      {
+        id: '2',
+        type: 'email',
+        title: 'Send follow-up email to Global Solutions',
+        description: 'Proposal sent 3 days ago - follow up needed',
+        suggestedTime: '3:15 PM',
+        priority: 'medium'
+      }
+    ],
+    pipelineData: [
+      {
+        id: '1',
+        company: 'TechCorp Inc.',
+        contact: 'Maria Rodriguez',
+        status: 'qualified',
+        priority: 'high',
+        value: '$125K',
+        avatar: 'T'
+      },
+      {
+        id: '2',
+        company: 'Global Solutions',
+        contact: 'Mike Chen',
+        status: 'proposal',
+        priority: 'medium',
+        value: '$85K',
+        avatar: 'G'
+      }
+    ]
+  });
+
+  const [loading, setLoading] = useState(false);
+
+  // Simulate real-time updates
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setData(prev => ({
+        ...prev,
+        aiAssistant: {
+          ...prev.aiAssistant,
+          performanceImprovement: prev.aiAssistant.performanceImprovement + Math.floor(Math.random() * 3 - 1)
+        }
+      }));
+    }, 30000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return { data, loading, setData };
+};

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,44 @@
+export interface AIAssistantStats {
+  emailsDrafted: number;
+  callsScheduled: number;
+  proposalsGenerated: number;
+  performanceImprovement: number;
+}
+
+export interface ScheduleItem {
+  id: string;
+  time: string;
+  title: string;
+  description: string;
+  duration: string;
+  priority: 'high' | 'medium' | 'low';
+  color: string;
+}
+
+export interface PriorityTask {
+  id: string;
+  type: 'call' | 'email' | 'meeting' | 'proposal';
+  title: string;
+  description: string;
+  suggestedTime: string;
+  priority: 'high' | 'medium' | 'low';
+  value?: string;
+}
+
+export interface PipelineLead {
+  id: string;
+  company: string;
+  contact: string;
+  status: 'qualified' | 'proposal' | 'negotiation' | 'closing';
+  priority: 'high' | 'medium' | 'low';
+  value: string;
+  avatar: string;
+}
+
+export interface DashboardData {
+  aiSummary: string;
+  aiAssistant: AIAssistantStats;
+  suggestedSchedule: ScheduleItem[];
+  priorityTasks: PriorityTask[];
+  pipelineData: PipelineLead[];
+}


### PR DESCRIPTION
## Summary
- add dashboard typings for AI components
- add dashboard data hook with mock data
- create AI dashboard components (Daily Summary, Assistant Hub, Suggested Schedule, Priority Tasks, Pipeline Pulse)
- add main Dashboard component using new components

## Testing
- `npx -y vitest run` *(fails: Cannot find package 'vitest')*

------
https://chatgpt.com/codex/tasks/task_e_6862757605348328a9c78e8e553bddfc