### PR TITLE
Improve logout flow and build splits

### DIFF
--- a/src/contexts/auth/AuthProvider.tsx
+++ b/src/contexts/auth/AuthProvider.tsx
@@ -197,7 +197,11 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(null);
       setSession(null);
       clearProfile();
-      
+      if (typeof window !== 'undefined') {
+        localStorage.clear();
+        sessionStorage.clear();
+      }
+
       // Supabase signout
       const { error } = await supabase.auth.signOut();
       
@@ -216,6 +220,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
       setUser(null);
       setSession(null);
       clearProfile();
+      if (typeof window !== 'undefined') {
+        localStorage.clear();
+        sessionStorage.clear();
+      }
       return { error: null };
     }
   };

--- a/src/utils/logoutOptimizer.ts
+++ b/src/utils/logoutOptimizer.ts
@@ -1,14 +1,18 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import { logger } from '@/utils/logger';
+import { useAuth } from '@/contexts/AuthContext';
 
-export const optimizedLogout = async (navigate: (path: string) => void) => {
+export const optimizedLogout = async (
+  signOut: () => Promise<any>,
+  navigate: (path: string) => void
+) => {
   try {
     // Immediate UI feedback - clear local state first
     const startTime = performance.now();
-    
-    // Fast logout without waiting for server response
-    const logoutPromise = supabase.auth.signOut();
+
+    // Trigger auth context sign out for immediate state clearing
+    const logoutPromise = signOut();
     
     // Immediate navigation - don't wait for logout to complete
     setTimeout(() => {
@@ -50,12 +54,13 @@ export const optimizedLogout = async (navigate: (path: string) => void) => {
 
 // Hook for consistent logout behavior
 export const useOptimizedLogout = () => {
+  const { signOut } = useAuth();
   const navigate = (path: string) => {
     // Use replace for instant navigation
     window.location.replace(path);
   };
 
   return {
-    logout: () => optimizedLogout(navigate)
+    logout: () => optimizedLogout(signOut, navigate)
   };
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,20 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          auth: [
+            'src/contexts/AuthContext',
+            'src/services/authService'
+          ],
+          dashboard: ['src/pages/Dashboard']
+        }
+      }
+    }
+  },
+  optimizeDeps: {
+    include: ['react', 'react-dom']
+  }
 }));


### PR DESCRIPTION
## Summary
- clear local/session storage on sign out
- call AuthProvider signOut from logout optimizer
- split auth code chunk in Vite build

## Testing
- `npm test --silent` *(fails: Landing page auth buttons > Get Started navigates to /auth)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68627993225483288b1d3c830af8ee1c