### PR TITLE
Add centralized AI configuration

### DIFF
--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -1,0 +1,18 @@
+export const aiConfig = {
+  claude: {
+    apiKey: import.meta.env.VITE_ANTHROPIC_API_KEY,
+    model: import.meta.env.VITE_CLAUDE_MODEL || 'claude-3-sonnet-20240229',
+    baseUrl: 'https://api.anthropic.com'
+  },
+  openai: {
+    apiKey: import.meta.env.VITE_OPENAI_API_KEY,
+    model: import.meta.env.VITE_OPENAI_MODEL || 'gpt-4o',
+    baseUrl: 'https://api.openai.com'
+  },
+  relevance: {
+    apiKey: import.meta.env.VITE_RELEVANCE_API_KEY,
+    baseUrl: import.meta.env.VITE_RELEVANCE_BASE_URL || 'https://api-bcbe36.stack.tryrelevance.com/latest'
+  }
+} as const;
+
+export type AIProvider = keyof typeof aiConfig;

--- a/src/services/relevance/RelevanceAgentService.ts
+++ b/src/services/relevance/RelevanceAgentService.ts
@@ -2,6 +2,7 @@
 import { logger } from '@/utils/logger';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { aiConfig } from '@/config/ai';
 
 export interface RelevanceAgentConfig {
   apiKey: string;
@@ -25,8 +26,8 @@ class RelevanceAgentService {
 
   constructor() {
     this.config = {
-      apiKey: import.meta.env.VITE_RELEVANCE_API_KEY || '',
-      baseUrl: 'https://api-bcbe36.stack.tryrelevance.com/latest',
+      apiKey: aiConfig.relevance.apiKey || '',
+      baseUrl: aiConfig.relevance.baseUrl,
       maxRetries: 3,
       retryDelay: 1000
     };


### PR DESCRIPTION
## Summary
- add `aiConfig` to centralize Claude, OpenAI, and Relevance AI settings
- use new configuration in `RelevanceAgentService`

## Testing
- `npx vitest run` *(fails: Landing page button test cannot find element)*

------
https://chatgpt.com/codex/tasks/task_e_68627b51c2a88328a2ac6c4b0705fdb1