### PR TITLE
Fix type mismatches in Company Brain modules

### DIFF
--- a/src/components/CompanyBrain/CompanyBrainManager.tsx
+++ b/src/components/CompanyBrain/CompanyBrainManager.tsx
@@ -23,6 +23,7 @@ import { toast } from 'sonner';
 import { useCompanyBrain } from '@/hooks/useCompanyBrain';
 import { DataSourceCard } from './types';
 import { DataSourceCardComponent } from './components/DataSourceCardComponent';
+import { AIInsight } from '@/services/companyBrain/types';
 import { EnhancedDataLibrary } from './components/EnhancedDataLibrary';
 import { SummaryHeader } from './components/SummaryHeader';
 import SocialMediaIntegrations from '@/components/Manager/SocialMediaIntegrations';
@@ -76,6 +77,14 @@ const CompanyBrainManager: React.FC = () => {
 
   const setCardTab = (cardId: string, tab: string) => {
     setActiveCardTab(prev => ({ ...prev, [cardId]: tab }));
+  };
+
+  const handleSendInsightEmail = (insight: AIInsight) => {
+    sendInsightEmail(insight).catch(console.error);
+  };
+
+  const handleCreateCampaignBrief = (insight: AIInsight) => {
+    createCampaignBrief(insight).catch(console.error);
   };
 
   const handleDismissError = (error: string) => {
@@ -297,8 +306,8 @@ const CompanyBrainManager: React.FC = () => {
                   uploadedFiles={uploadedFiles}
                   websiteData={websiteData}
                   insights={insights}
-                  sendInsightEmail={sendInsightEmail}
-                  createCampaignBrief={createCampaignBrief}
+                  sendInsightEmail={handleSendInsightEmail}
+                  createCampaignBrief={handleCreateCampaignBrief}
                 />
               ))}
             </div>

--- a/src/hooks/useCompanyBrain.ts
+++ b/src/hooks/useCompanyBrain.ts
@@ -2,66 +2,18 @@
 import { useState, useCallback } from 'react';
 import { toast } from 'sonner';
 import { logger } from '@/utils/logger';
-
-interface WebsiteData {
-  url: string;
-  pages: number;
-  lastCrawled: Date;
-  content?: {
-    title: string;
-    description: string;
-    keywords: string[];
-    contentSummary: string;
-  };
-}
-
-interface SocialConnection {
-  platform: string;
-  connected: boolean;
-  lastSync?: Date;
-}
-
-interface UploadedFile {
-  id: string;
-  name: string;
-  size: number;
-  uploadedAt: Date;
-  uploadDate: Date;
-  type: string;
-  category: string;
-  tags: string[];
-  url: string;
-}
-
-interface DataStatus {
-  totalFiles: number;
-  totalSources: number;
-  lastUpdate: Date;
-  processingStatus: 'idle' | 'processing' | 'completed' | 'error';
-  errors: string[];
-  social: {
-    connected: number;
-    totalPlatforms: number;
-  };
-}
-
-interface AIInsight {
-  id: string;
-  title: string;
-  description: string;
-  confidence: number;
-  createdAt: Date;
-  category: string;
-  type: string;
-  summary: string;
-  suggestion: string;
-  data: any;
-}
+import {
+  WebsiteData,
+  SocialMediaConnection,
+  UploadedFile,
+  DataIngestionStatus,
+  AIInsight
+} from '@/services/companyBrain/types';
 
 export const useCompanyBrain = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [websiteData, setWebsiteData] = useState<WebsiteData | null>(null);
-  const [socialConnections, setSocialConnections] = useState<SocialConnection[]>([
+  const [socialConnections, setSocialConnections] = useState<SocialMediaConnection[]>([
     { platform: 'instagram', connected: false },
     { platform: 'facebook', connected: false },
     { platform: 'linkedin', connected: false },
@@ -69,16 +21,22 @@ export const useCompanyBrain = () => {
   ]);
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [insights, setInsights] = useState<AIInsight[]>([]);
-  const [dataStatus, setDataStatus] = useState<DataStatus>({
+  const [dataStatus, setDataStatus] = useState<
+    DataIngestionStatus & {
+      totalFiles: number;
+      totalSources: number;
+      lastUpdate: Date;
+      processingStatus: 'idle' | 'processing' | 'completed' | 'error';
+    }
+  >({
+    social: { connected: 0, total: 4 },
+    website: { status: 'disconnected' },
+    documents: { count: 0 },
+    errors: [],
     totalFiles: 0,
     totalSources: 0,
     lastUpdate: new Date(),
-    processingStatus: 'idle',
-    errors: [],
-    social: {
-      connected: 0,
-      totalPlatforms: 4
-    }
+    processingStatus: 'idle'
   });
 
   const crawlWebsite = useCallback(async (url: string): Promise<WebsiteData | null> => {
@@ -212,7 +170,7 @@ export const useCompanyBrain = () => {
           confidence: 0.85,
           createdAt: new Date(),
           category: 'content',
-          type: 'analysis',
+          type: 'website',
           summary: 'Content analysis shows gaps in technical documentation',
           suggestion: 'Create more detailed product feature content',
           data: { gaps: ['technical specs', 'integration guides'] }
@@ -224,7 +182,7 @@ export const useCompanyBrain = () => {
           confidence: 0.72,
           createdAt: new Date(),
           category: 'branding',
-          type: 'consistency',
+          type: 'social',
           summary: 'Inconsistent brand voice across channels',
           suggestion: 'Align social media tone with website messaging',
           data: { channels: ['social', 'website'] }

--- a/src/services/agents/AgentOrchestrator.ts
+++ b/src/services/agents/AgentOrchestrator.ts
@@ -26,6 +26,8 @@ export interface AgentContext {
   rehearsalTopic?: string;
   pitchText?: string;
   userResponse?: string;
+  scenario?: string;
+  metadata?: Record<string, any>;
 }
 
 export interface AgentTask {

--- a/src/services/ai/hybridAIOrchestrator.ts
+++ b/src/services/ai/hybridAIOrchestrator.ts
@@ -77,12 +77,11 @@ export class HybridAIOrchestrator {
             result = summaryResponse.response;
             source = summaryResponse.source;
           } else {
-            const quickResponse = await unifiedAIService.performQuickAnalysis(
-              `Summarize: ${task.input}`,
-              task.context
+            const quickResult = await unifiedAIService.performQuickAnalysis(
+              `Summarize: ${task.input}`
             );
-            result = quickResponse.response;
-            source = quickResponse.source;
+            result = quickResult;
+            source = 'openai';
           }
           break;
 


### PR DESCRIPTION
## Summary
- import shared CompanyBrain types in `useCompanyBrain` hook
- map mock insights to correct union types
- wrap async insight handlers in `CompanyBrainManager`
- extend `AgentContext` with optional `scenario` and `metadata`
- fix quick analysis call in `hybridAIOrchestrator`

## Testing
- `npx tsc --noEmit`
- `npm run build`
- `npm test` *(fails: Unable to find accessible element)*

------
https://chatgpt.com/codex/tasks/task_e_686388f5c3e08328b8b80664ea6d3d1d