### PR TITLE
Fix auth loading and dashboard routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,37 +11,31 @@ import LoadingScreen from '@/components/LoadingScreen';
 import { logger } from '@/utils/logger';
 
 const AppRoutes: React.FC = () => {
-  const { user, profile, loading } = useAuth();
+  const { session, loading } = useAuth();
 
-  // Show loading spinner while determining auth state
-  if (loading) {
-    return <LoadingScreen />;
-  }
+  if (loading) return <LoadingScreen />;
 
-  // If user is authenticated, determine role-based routing
-  if (user && profile) {
-    logger.info('✅ User authenticated, routing based on role:', { role: profile.role }, 'auth');
-    
+  if (!session) {
     return (
       <Routes>
+        <Route path="/" element={<NewLandingPage />} />
+        <Route path="/auth" element={<AuthPage />} />
         <Route path="/logout" element={<LogoutHandler />} />
-        <Route path="/*" element={<MainLayout />} />
+        <Route path="/*" element={<Navigate to="/auth" replace />} />
       </Routes>
     );
   }
 
-  // If user exists but no profile, show loading or redirect to complete setup
-  if (user && !profile) {
-    return <LoadingScreen message="Setting up your profile..." subMessage="This will only take a moment" />;
+  if (session?.user?.role === 'manager') {
+    return <Navigate to="/manager/dashboard" replace />;
+  } else if (session?.user?.role === 'sales' || session?.user?.role === 'sales_rep') {
+    return <Navigate to="/sales/dashboard" replace />;
   }
 
-  // If not authenticated, show auth/landing pages
   return (
     <Routes>
-      <Route path="/" element={<NewLandingPage />} />
-      <Route path="/auth" element={<AuthPage />} />
       <Route path="/logout" element={<LogoutHandler />} />
-      <Route path="/*" element={<Navigate to="/auth" replace />} />
+      <Route path="/*" element={<MainLayout />} />
     </Routes>
   );
 };

--- a/src/pages/sales/Dashboard.tsx
+++ b/src/pages/sales/Dashboard.tsx
@@ -3,47 +3,16 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import LoadingScreen from '@/components/LoadingScreen';
 import EnhancedSalesRepDashboard from './EnhancedSalesRepDashboard';
-import { logger } from '@/utils/logger';
 
 export default function SalesDashboardPage() {
-  const { session, user, profile, loading } = useAuth();
+  const { session, loading } = useAuth();
 
   useEffect(() => {
-    logger.info('🏠 Sales Dashboard mounted:', { 
-      hasSession: !!session, 
-      hasUser: !!user, 
-      hasProfile: !!profile,
-      role: profile?.role 
-    }, 'dashboard');
-  }, [session, user, profile]);
+    console.log('SESSION:', session);
+  }, [session]);
 
-  if (loading) {
-    logger.info('📱 Dashboard loading...', {}, 'dashboard');
-    return <LoadingScreen message="Loading dashboard..." />;
-  }
+  if (loading) return <LoadingScreen />;
+  if (!session) return <Navigate to="/auth" replace />;
 
-  if (!session || !user) {
-    logger.warn('🚫 No session in dashboard, redirecting to auth', {}, 'dashboard');
-    return <Navigate to="/auth" replace />;
-  }
-
-  if (!profile) {
-    logger.warn('🚫 No profile in dashboard, redirecting to auth', {}, 'dashboard');
-    return <Navigate to="/auth" replace />;
-  }
-
-  try {
-    logger.info('✅ Rendering sales dashboard', { role: profile.role }, 'dashboard');
-    return <EnhancedSalesRepDashboard />;
-  } catch (error) {
-    logger.error('❌ Error rendering dashboard:', error, 'dashboard');
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-xl font-bold text-destructive mb-4">Dashboard Error</h1>
-          <p className="text-muted-foreground">Please refresh the page or contact support.</p>
-        </div>
-      </div>
-    );
-  }
+  return <EnhancedSalesRepDashboard />;
 }


### PR DESCRIPTION
## Summary
- fix session resolution in `AuthProvider`
- update route gating in `AppRoutes`
- simplify sales dashboard page and add logging

## Testing
- `npm run build`
- `npm test` *(fails: Landing page auth buttons > Get Started navigates to /auth)*

------
https://chatgpt.com/codex/tasks/task_e_6865185b39f48328a58f6c1a87960333