### PR TITLE
Fix auth loading loop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { DemoDataProvider } from '@/contexts/DemoDataContext';
@@ -13,7 +13,11 @@ import { logger } from '@/utils/logger';
 const AppRoutes: React.FC = () => {
   const { session, loading } = useAuth();
 
-  if (loading) return <LoadingScreen />;
+  useEffect(() => {
+    console.log('\uD83D\uDD0D Auth Debug \u2014 session:', session, '| loading:', loading);
+  }, [session, loading]);
+
+  if (loading) return <LoadingScreen message="Preparing your workspace..." />;
 
   if (!session) {
     return (


### PR DESCRIPTION
## Summary
- fix AuthProvider loading loop & add fallback timer
- add debug logs for auth loading in App

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651b0a63f0832897f638dd5058485d