### PR TITLE
Fix auth loading & secure dashboard

### DIFF
--- a/src/components/FallbackError.tsx
+++ b/src/components/FallbackError.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const FallbackError: React.FC = () => (
+  <div className="p-6 text-center text-red-600">
+    <h2 className="text-xl font-bold">Something broke 😬</h2>
+    <p>Dashboard failed to load. Try refreshing or contact support.</p>
+  </div>
+);
+
+export default FallbackError;

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+import LoadingScreen from '@/components/LoadingScreen';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const ProtectedRoute: React.FC<Props> = ({ children }) => {
+  const { session, loading } = useAuth();
+
+  if (loading) return <LoadingScreen message="Validating session..." />;
+  if (!session) return <Navigate to="/auth" replace />;
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/src/contexts/auth/AuthProvider.tsx
+++ b/src/contexts/auth/AuthProvider.tsx
@@ -49,12 +49,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Initialize auth state
   useEffect(() => {
-    const fetchSession = async () => {
+    const getSession = async () => {
       try {
-        const { data, error } = await supabase.auth.getSession();
-        if (error) {
-          console.error('Session fetch error:', error);
-        }
+        const { data } = await supabase.auth.getSession();
+        console.log('🔐 Fetched session:', data?.session);
 
         setSession(data?.session ?? null);
         setUser(data?.session?.user ?? null);
@@ -65,28 +63,28 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
         } else {
           setProfile(null);
         }
-      } catch (err) {
-        console.error('Unexpected session error:', err);
+      } catch (e) {
+        console.error('❌ Session fetch failed:', e);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchSession();
+    getSession();
 
-    const { data: listener } = supabase.auth.onAuthStateChange(async (_event, session) => {
+    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+      console.log('🔄 Auth state change:', event, session);
       setSession(session);
       setUser(session?.user ?? null);
       if (session?.user) {
-        const profileData = await fetchUserProfile(session.user.id);
-        setProfile(profileData);
+        fetchUserProfile(session.user.id).then(setProfile);
       } else {
         setProfile(null);
       }
-      setLoading(false); // ensure loading false on auth changes
+      setLoading(false);
     });
 
-    return () => listener?.subscription?.unsubscribe();
+    return () => listener.subscription.unsubscribe();
   }, []);
 
   // Fallback: prevent infinite loading state

--- a/src/layouts/SalesRepOS.tsx
+++ b/src/layouts/SalesRepOS.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import SalesRepNavigation from '@/components/Navigation/SalesRepNavigation';
 import ContextAwareAIBubble from '@/components/UnifiedAI/ContextAwareAIBubble';
@@ -8,6 +8,10 @@ import AgentTriggerButton from '@/frontend/automations-ui/AgentTriggerButton';
 
 // Sales Rep Pages  
 import SalesRepDashboard from '@/pages/sales/SalesRepDashboard';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import ErrorBoundary from '@/components/ErrorBoundary';
+import FallbackError from '@/components/FallbackError';
+import LoadingScreen from '@/components/LoadingScreen';
 import LeadManagement from '@/pages/LeadManagement';
 import LeadWorkspace from '@/pages/LeadWorkspace';
 import Dialer from '@/pages/Dialer';
@@ -28,7 +32,18 @@ const SalesRepOS: React.FC = () => {
       <main className="pt-16 lg:pt-20">
         <Routes>
           <Route index element={<Navigate to="dashboard" replace />} />
-          <Route path="dashboard" element={<SalesRepDashboard />} />
+          <Route
+            path="dashboard"
+            element={
+              <ProtectedRoute>
+                <Suspense fallback={<LoadingScreen message="Preparing your sales OS..." />}>
+                  <ErrorBoundary fallback={<FallbackError />}>
+                    <SalesRepDashboard />
+                  </ErrorBoundary>
+                </Suspense>
+              </ProtectedRoute>
+            }
+          />
           <Route path="leads" element={<LeadManagement />} />
           <Route path="leads/:leadId" element={<LeadWorkspace />} />
           <Route path="my-leads" element={<LeadManagement />} />

--- a/src/pages/sales/Dashboard.tsx
+++ b/src/pages/sales/Dashboard.tsx
@@ -11,6 +11,10 @@ export default function SalesDashboardPage() {
     console.log('SESSION:', session);
   }, [session]);
 
+  useEffect(() => {
+    console.log('✅ Dashboard mounted');
+  }, []);
+
   if (loading) return <LoadingScreen />;
   if (!session) return <Navigate to="/auth" replace />;
 


### PR DESCRIPTION
## Summary
- improve session initialization logic in AuthProvider
- add new ProtectedRoute and FallbackError components
- guard sales dashboard route with Suspense and error boundary
- log when dashboard mounts

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651c5a0c5c8328b85ad095afd3bc2e