### PR TITLE
Improve auth and dashboard stability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,13 +11,11 @@ import LoadingScreen from '@/components/LoadingScreen';
 import { logger } from '@/utils/logger';
 
 const AppRoutes: React.FC = () => {
-  const { session, loading } = useAuth();
+  const { session } = useAuth();
 
   useEffect(() => {
-    console.log('\uD83D\uDD0D Auth Debug \u2014 session:', session, '| loading:', loading);
-  }, [session, loading]);
-
-  if (loading) return <LoadingScreen message="Preparing your workspace..." />;
+    console.log('\uD83D\uDD0D Auth Debug \u2014 session:', session);
+  }, [session]);
 
   if (!session) {
     return (
@@ -44,12 +42,17 @@ const AppRoutes: React.FC = () => {
   );
 };
 
+const AuthGate: React.FC = () => {
+  const { loading } = useAuth();
+  return loading ? <LoadingScreen message="Resolving auth..." /> : <AppRoutes />;
+};
+
 const App: React.FC = () => {
   return (
     <Router>
       <AuthProvider>
         <DemoDataProvider>
-          <AppRoutes />
+          <AuthGate />
         </DemoDataProvider>
       </AuthProvider>
     </Router>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -10,10 +10,13 @@ interface Props {
 const ProtectedRoute: React.FC<Props> = ({ children }) => {
   const { session, loading } = useAuth();
 
-  if (loading) return <LoadingScreen message="Validating session..." />;
-  if (!session) return <Navigate to="/auth" replace />;
+  if (loading) return <LoadingScreen message="Checking session..." />;
+  if (!session) {
+    console.warn('🧯 No session found. Redirecting to /auth');
+    return <Navigate to="/auth" replace />;
+  }
 
-  return <>{children}</>;
+  return children;
 };
 
 export default ProtectedRoute;

--- a/src/contexts/auth/AuthProvider.tsx
+++ b/src/contexts/auth/AuthProvider.tsx
@@ -49,31 +49,36 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Initialize auth state
   useEffect(() => {
-    const getSession = async () => {
+    const fetchSession = async () => {
       try {
-        const { data } = await supabase.auth.getSession();
-        console.log('🔐 Fetched session:', data?.session);
-
-        setSession(data?.session ?? null);
-        setUser(data?.session?.user ?? null);
-
-        if (data?.session?.user) {
-          const profileData = await fetchUserProfile(data.session.user.id);
+        console.log('🔁 Fetching Supabase session...');
+        const {
+          data: { session },
+          error
+        } = await supabase.auth.getSession();
+        if (error) {
+          console.error('❌ Supabase session error:', error);
+        }
+        setSession(session ?? null);
+        setUser(session?.user ?? null);
+        if (session?.user) {
+          const profileData = await fetchUserProfile(session.user.id);
           setProfile(profileData);
         } else {
           setProfile(null);
         }
       } catch (e) {
-        console.error('❌ Session fetch failed:', e);
+        console.error('❌ Exception fetching session:', e);
       } finally {
+        console.log('✅ Auth loading finished');
         setLoading(false);
       }
     };
 
-    getSession();
+    fetchSession();
 
     const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
-      console.log('🔄 Auth state change:', event, session);
+      console.log('🔄 Auth state changed:', event);
       setSession(session);
       setUser(session?.user ?? null);
       if (session?.user) {

--- a/src/layouts/SalesRepOS.tsx
+++ b/src/layouts/SalesRepOS.tsx
@@ -7,7 +7,7 @@ import { useMockData } from '@/hooks/useMockData';
 import AgentTriggerButton from '@/frontend/automations-ui/AgentTriggerButton';
 
 // Sales Rep Pages  
-import SalesRepDashboard from '@/pages/sales/SalesRepDashboard';
+import SalesDashboard from '@/pages/sales/Dashboard';
 import ProtectedRoute from '@/components/ProtectedRoute';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import FallbackError from '@/components/FallbackError';
@@ -36,11 +36,11 @@ const SalesRepOS: React.FC = () => {
             path="dashboard"
             element={
               <ProtectedRoute>
-                <Suspense fallback={<LoadingScreen message="Preparing your sales OS..." />}>
-                  <ErrorBoundary fallback={<FallbackError />}>
-                    <SalesRepDashboard />
-                  </ErrorBoundary>
-                </Suspense>
+                <ErrorBoundary fallback={<div className="p-8 text-center text-red-600">❌ Dashboard crashed</div>}>
+                  <Suspense fallback={<LoadingScreen message="Loading dashboard..." />}>
+                    <SalesDashboard />
+                  </Suspense>
+                </ErrorBoundary>
               </ProtectedRoute>
             }
           />

--- a/src/pages/sales/Dashboard.tsx
+++ b/src/pages/sales/Dashboard.tsx
@@ -12,7 +12,7 @@ export default function SalesDashboardPage() {
   }, [session]);
 
   useEffect(() => {
-    console.log('✅ Dashboard mounted');
+    console.log('🧩 SalesDashboard mounted successfully');
   }, []);
 
   if (loading) return <LoadingScreen />;


### PR DESCRIPTION
## Summary
- tweak auth provider to log session fetching and auth state changes
- lock route rendering until auth has resolved
- add error boundary and suspense to sales dashboard route
- clarify protected route fallback and logging
- log dashboard mount

## Testing
- `npm run lint`
- `npm test` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_68651e7fe3d08328879d6fc6247e7cd9