### PR TITLE
Improve Sales Dashboard handling

### DIFF
--- a/src/hooks/useSomeSalesData.ts
+++ b/src/hooks/useSomeSalesData.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react';
+import { logger } from '@/utils/logger';
+
+export interface SalesInsight {
+  id: string;
+  title: string;
+}
+
+export interface SalesData {
+  rep: { name: string } | null;
+  insights: SalesInsight[];
+}
+
+export const useSomeSalesData = () => {
+  const [data, setData] = useState<SalesData | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchData = async () => {
+      try {
+        // Simulate network fetch delay
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        if (!isMounted) return;
+        setData({
+          rep: { name: 'Demo Rep' },
+          insights: [
+            { id: '1', title: 'Follow up with open leads' },
+            { id: '2', title: 'Schedule calls with top prospects' },
+          ],
+        });
+      } catch (err) {
+        if (isMounted) {
+          setError(err as Error);
+          logger.error('Failed to fetch sales data', err);
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    };
+
+    fetchData();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return { data, error, isLoading };
+};

--- a/src/layouts/SalesRepOS.tsx
+++ b/src/layouts/SalesRepOS.tsx
@@ -7,10 +7,8 @@ import { useMockData } from '@/hooks/useMockData';
 import AgentTriggerButton from '@/frontend/automations-ui/AgentTriggerButton';
 
 // Sales Rep Pages  
-import SalesDashboard from '@/pages/sales/Dashboard';
+import SalesDashboardWrapper from '@/pages/sales/SalesDashboardWrapper';
 import ProtectedRoute from '@/components/ProtectedRoute';
-import ErrorBoundary from '@/components/ErrorBoundary';
-import FallbackError from '@/components/FallbackError';
 import LoadingScreen from '@/components/LoadingScreen';
 import LeadManagement from '@/pages/LeadManagement';
 import LeadWorkspace from '@/pages/LeadWorkspace';
@@ -36,11 +34,9 @@ const SalesRepOS: React.FC = () => {
             path="dashboard"
             element={
               <ProtectedRoute>
-                <ErrorBoundary fallback={<div className="p-8 text-center text-red-600">❌ Dashboard crashed</div>}>
-                  <Suspense fallback={<LoadingScreen message="Loading dashboard..." />}>
-                    <SalesDashboard />
-                  </Suspense>
-                </ErrorBoundary>
+                <Suspense fallback={<LoadingScreen message="Loading dashboard..." />}>
+                  <SalesDashboardWrapper />
+                </Suspense>
               </ProtectedRoute>
             }
           />

--- a/src/pages/sales/Dashboard.tsx
+++ b/src/pages/sales/Dashboard.tsx
@@ -3,20 +3,48 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import LoadingScreen from '@/components/LoadingScreen';
 import EnhancedSalesRepDashboard from './EnhancedSalesRepDashboard';
+import { useSomeSalesData } from '@/hooks/useSomeSalesData';
 
-export default function SalesDashboardPage() {
-  const { session, loading } = useAuth();
-
-  useEffect(() => {
-    console.log('SESSION:', session);
-  }, [session]);
+export default function SalesDashboard() {
+  const { user, loading } = useAuth();
+  const { data, error, isLoading } = useSomeSalesData();
 
   useEffect(() => {
-    console.log('🧩 SalesDashboard mounted successfully');
+    console.log('🧩 SalesDashboard mounted');
   }, []);
 
   if (loading) return <LoadingScreen />;
-  if (!session) return <Navigate to="/auth" replace />;
+  if (!user) {
+    console.warn('🚫 No user in SalesDashboard');
+    return <Navigate to="/auth" replace />;
+  }
 
-  return <EnhancedSalesRepDashboard />;
+  if (error) {
+    console.error('🔥 Sales data fetch error:', error);
+    return <div className="text-red-600">Failed to load sales data</div>;
+  }
+
+  if (isLoading || !data) {
+    return <LoadingScreen message="Loading sales insights..." />;
+  }
+
+  const insights = data?.insights ?? [];
+  const name = data?.rep?.name ?? 'Unknown Rep';
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Welcome back, {name}</h1>
+      {insights.length === 0 ? (
+        <p>No insights yet.</p>
+      ) : (
+        <ul>
+          {insights.map((i) => (
+            <li key={i.id}>{i.title}</li>
+          ))}
+        </ul>
+      )}
+      {/* Existing dashboard content */}
+      <EnhancedSalesRepDashboard />
+    </div>
+  );
 }

--- a/src/pages/sales/SalesDashboardWrapper.tsx
+++ b/src/pages/sales/SalesDashboardWrapper.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ErrorBoundary from '@/components/ErrorBoundary';
+import SalesDashboard from './Dashboard';
+
+export default function SalesDashboardWrapper() {
+  return (
+    <ErrorBoundary fallback={<div className="p-8 text-center text-red-600">❌ Sales Dashboard Crashed</div>}>
+      <SalesDashboard />
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
- add `useSomeSalesData` hook for demo data fetching
- make Sales Dashboard log mounts and handle null states
- add SalesDashboardWrapper with error boundary
- update SalesRepOS to use wrapper

## Testing
- `npm test` *(fails: Landing page auth buttons > Get Started navigates to /auth)*

------
https://chatgpt.com/codex/tasks/task_e_6865221c50688328b56a7eab4db3a847