### PR TITLE
Fix routing auth flow and AI provider

### DIFF
--- a/src/__tests__/landingPageButtons.test.tsx
+++ b/src/__tests__/landingPageButtons.test.tsx
@@ -44,7 +44,7 @@ describe('Landing page auth buttons', () => {
         <Wrapper />
       </MemoryRouter>
     );
-    const btn = screen.getAllByRole('button', { name: /get started/i })[0];
+    const btn = screen.getAllByRole('button', { name: /try for free/i })[0];
     fireEvent.click(btn);
     await waitFor(() => {
       expect(screen.getByTestId('location').textContent).toBe('/auth');

--- a/src/pages/SafeModePage.tsx
+++ b/src/pages/SafeModePage.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function SafeModePage() {
+  return (
+    <div style={{ padding: 40 }}>
+      ✅ App is rendering — AI context, require(), and redirect loop removed.
+    </div>
+  );
+}

--- a/src/utils/logoutOptimizer.ts
+++ b/src/utils/logoutOptimizer.ts
@@ -1,5 +1,6 @@
 
 import { logger } from '@/utils/logger';
+import { useAuth } from '@/contexts/AuthContext';
 
 export const optimizedLogout = async (
   signOut: () => Promise<any>
@@ -22,7 +23,7 @@ export const optimizedLogout = async (
 
 // Hook for consistent logout behavior
 export const useOptimizedLogout = () => {
-  const { signOut } = require('@/contexts/AuthContext').useAuth();
+  const { signOut } = useAuth();
 
   return {
     logout: () => optimizedLogout(signOut)


### PR DESCRIPTION
## Summary
- ensure auth routing waits for hydration before redirecting
- add SafeModePage and route
- wrap app with UnifiedAIProvider
- replace require with import in logout optimizer
- update button test text

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68652b2744e083289b4bd56db415d5df