### PR TITLE
Restore safe fallback UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,96 +1,28 @@
-
 import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
-import { AuthProvider, useAuth } from '@/contexts/AuthContext';
-import { DemoDataProvider } from '@/contexts/DemoDataContext';
-import { UnifiedAIProvider } from '@/contexts/UnifiedAIContext';
-import AuthPage from '@/pages/auth/AuthPage';
-import MainLayout from '@/layouts/MainLayout';
-import SafeModePage from '@/pages/SafeModePage';
-import LogoutHandler from '@/components/LogoutHandler';
-import NewLandingPage from '@/pages/NewLandingPage';
-import LoadingScreen from '@/components/LoadingScreen';
-import { supabase } from '@/integrations/supabase/client';
+import Auth from './pages/auth';
+import SafeDash from './pages/safe-dashboard';
 
-const AppRoutes: React.FC = () => {
-  const { session, loading } = useAuth();
-  const navigate = useNavigate();
-  const [hydrated, setHydrated] = React.useState(false);
-
+export default function App() {
   useEffect(() => {
-    setHydrated(true);
+    const demoSession = localStorage.getItem('demo-auth');
+    if (!demoSession && typeof window !== 'undefined') {
+      console.log('⚠️ No session found. Redirecting to /auth');
+      if (window.location.pathname !== '/auth') {
+        window.location.href = '/auth';
+      }
+    } else {
+      console.log('🔁 Demo session exists. Proceeding...');
+    }
   }, []);
 
-  // Validate session directly with Supabase to avoid auth loops
-  useEffect(() => {
-    const checkSession = async () => {
-      const { data: { session } } = await supabase.auth.getSession();
-      if (!session) {
-        navigate('/auth', { replace: true });
-      } else {
-        const role = (session.user as any)?.role || 'sales';
-        const target = role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
-        if (window.location.pathname !== target) {
-          navigate(target, { replace: true });
-        }
-      }
-    };
-    checkSession();
-  }, [navigate]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined' && hydrated && session && !loading) {
-      const role = (session.user as any)?.role;
-      const target = !session.user
-        ? '/auth'
-        : role === 'manager'
-          ? '/manager/dashboard'
-          : '/sales/dashboard';
-
-      if (window.location.pathname !== target) {
-        navigate(target, { replace: true });
-      }
-    }
-  }, [hydrated, session, loading, navigate]);
-
-  if (!session) {
-    return (
-      <Routes>
-        <Route path="/" element={<NewLandingPage />} />
-        <Route path="/auth" element={<AuthPage />} />
-        <Route path="/safe" element={<SafeModePage />} />
-        <Route path="/logout" element={<LogoutHandler />} />
-        <Route path="/*" element={<Navigate to="/auth" replace />} />
-      </Routes>
-    );
-  }
-
-  return (
-    <Routes>
-      <Route path="/logout" element={<LogoutHandler />} />
-      <Route path="/safe" element={<SafeModePage />} />
-      <Route path="/*" element={<MainLayout />} />
-    </Routes>
-  );
-};
-
-const AuthGate: React.FC = () => {
-  const { loading } = useAuth();
-  return loading ? <LoadingScreen message="Resolving auth..." /> : <AppRoutes />;
-};
-
-const App: React.FC = () => {
   return (
     <Router>
-      <AuthProvider>
-        <DemoDataProvider>
-          <UnifiedAIProvider>
-            <AuthGate />
-          </UnifiedAIProvider>
-        </DemoDataProvider>
-      </AuthProvider>
+      <Routes>
+        <Route path="/auth" element={<Auth />} />
+        <Route path="/safe-dashboard" element={<SafeDash />} />
+        <Route path="/*" element={<Navigate to="/safe-dashboard" replace />} />
+      </Routes>
     </Router>
   );
-};
-
-export default App;
+}

--- a/src/components/AIAssistant.tsx
+++ b/src/components/AIAssistant.tsx
@@ -6,7 +6,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { MessageCircle, ChevronUp, ChevronDown, Zap, Settings } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/contexts/AuthContext";
-import { useUnifiedAI } from "@/contexts/UnifiedAIContext";
+// import { useUnifiedAI } from "@/contexts/UnifiedAIContext";
 import { toast } from "sonner";
 
 // Import our components
@@ -75,7 +75,7 @@ const AIAssistant = () => {
   ]);
   
   const { user } = useAuth();
-  const { generateAIResponse, generateStrategyResponse, generateCommunication } = useUnifiedAI();
+  // const { generateAIResponse, generateStrategyResponse, generateCommunication } = useUnifiedAI();
   const [isLoading, setIsLoading] = useState(false);
   
   // Handle sending a message using the Unified AI Service
@@ -113,14 +113,15 @@ const AIAssistant = () => {
         const inputLower = currentInput.toLowerCase();
         
         if (inputLower.includes('strategy') || inputLower.includes('analyze') || inputLower.includes('plan')) {
-          response = await generateStrategyResponse(currentInput);
-          toast.success('Strategic analysis generated with Claude');
+          // response = await generateStrategyResponse(currentInput);
+          response = 'Strategy service disabled in safe mode.';
         } else if (inputLower.includes('email') || inputLower.includes('draft') || inputLower.includes('write')) {
-          response = await generateCommunication(currentInput);
-          toast.success('Communication drafted with Claude');
+          // response = await generateCommunication(currentInput);
+          response = 'Communication service disabled in safe mode.';
         } else {
-          response = await generateAIResponse(currentInput);
-          toast.success('Response generated with AI');
+          // response = await generateAIResponse(currentInput);
+          response = 'AI response disabled in safe mode.';
+          
         }
         
         // Add AI response to messages
@@ -187,11 +188,14 @@ const AIAssistant = () => {
       
       // Route to appropriate AI service based on action type
       if (action.toLowerCase().includes('strategy') || action.toLowerCase().includes('analyze')) {
-        response = await generateStrategyResponse(`Execute action: ${action}`);
+        // response = await generateStrategyResponse(`Execute action: ${action}`);
+        response = 'Strategy service disabled in safe mode.';
       } else if (action.toLowerCase().includes('email') || action.toLowerCase().includes('draft')) {
-        response = await generateCommunication(`Execute action: ${action}`);
+        // response = await generateCommunication(`Execute action: ${action}`);
+        response = 'Communication service disabled in safe mode.';
       } else {
-        response = await generateAIResponse(`Execute action: ${action}`);
+        // response = await generateAIResponse(`Execute action: ${action}`);
+        response = 'AI response disabled in safe mode.';
       }
       
       // Add AI response

--- a/src/components/ManagerAI/ManagerAIPanel.tsx
+++ b/src/components/ManagerAI/ManagerAIPanel.tsx
@@ -18,7 +18,7 @@ import {
   Settings,
   Lightbulb
 } from 'lucide-react';
-import { useUnifiedAI } from '@/contexts/UnifiedAIContext';
+// import { useUnifiedAI } from '@/contexts/UnifiedAIContext';
 import { toast } from 'sonner';
 
 interface ManagerAIPanelProps {
@@ -39,7 +39,7 @@ const ManagerAIPanel: React.FC<ManagerAIPanelProps> = ({
   const [question, setQuestion] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
   const [responses, setResponses] = useState<Array<{id: string, question: string, answer: string, timestamp: Date}>>([]);
-  const { logAIInteraction } = useUnifiedAI();
+  // const { logAIInteraction } = useUnifiedAI();
 
   const handleAskJarvis = async () => {
     if (!question.trim() || isProcessing) return;
@@ -61,12 +61,11 @@ const ManagerAIPanel: React.FC<ManagerAIPanelProps> = ({
         
         setResponses(prev => [newResponse, ...prev]);
         
-        // Log the interaction
-        await logAIInteraction('jarvis_interaction', {
-          question: currentQuestion,
-          response_length: response.length,
-          success: true
-        });
+        // await logAIInteraction('jarvis_interaction', {
+        //   question: currentQuestion,
+        //   response_length: response.length,
+        //   success: true
+        // });
         
         toast.success('Jarvis response generated');
       }
@@ -94,10 +93,10 @@ const ManagerAIPanel: React.FC<ManagerAIPanelProps> = ({
         
         setResponses(prev => [reportResponse, ...prev]);
         
-        await logAIInteraction('executive_report', {
-          report_length: report.length,
-          success: true
-        });
+        // await logAIInteraction('executive_report', {
+        //   report_length: report.length,
+        //   success: true
+        // });
         
         toast.success('Executive report generated');
       }

--- a/src/components/UnifiedAI/ContextAwareAIBubble.tsx
+++ b/src/components/UnifiedAI/ContextAwareAIBubble.tsx
@@ -16,7 +16,7 @@ import {
   Mail,
   User
 } from 'lucide-react';
-import { useUnifiedAI } from '@/contexts/UnifiedAIContext';
+// import { useUnifiedAI } from '@/contexts/UnifiedAIContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 
@@ -53,7 +53,8 @@ const ContextAwareAIBubble: React.FC<ContextAwareAIBubbleProps> = ({ context, cl
   const [isLoading, setIsLoading] = useState(false);
   
   const { profile } = useAuth();
-  const { executeAgentTask, isAIActive } = useUnifiedAI();
+  // const { executeAgentTask, isAIActive } = useUnifiedAI();
+  const isAIActive = false;
 
   const getContextualGreeting = () => {
     const role = profile?.role || 'user';
@@ -132,29 +133,36 @@ const ContextAwareAIBubble: React.FC<ContextAwareAIBubbleProps> = ({ context, cl
     }]);
 
     try {
-      const agentType = profile?.role === 'manager' ? 'managerAgent_v1' : 'salesAgent_v1';
-      
-      const result = await executeAgentTask(agentType, 'contextual_assistance', {
-        message: userMessage,
-        workspace: context.workspace,
-        leadContext: context.currentLead,
-        callContext: context.isCallActive ? { duration: context.callDuration } : null,
-        emailContext: context.emailContext,
-        smsContext: context.smsContext
-      });
+      // const agentType = profile?.role === 'manager' ? 'managerAgent_v1' : 'salesAgent_v1';
 
-      if (result && result.status === 'completed') {
-        const aiResponse = result.output?.response || "I'm here to help! Could you be more specific about what you need?";
-        
-        setConversation(prev => [...prev, {
-          role: 'assistant',
-          content: aiResponse,
-          timestamp: new Date(),
-          source: result.agentType
-        }]);
-      } else {
-        throw new Error('Agent response failed');
-      }
+      // const result = await executeAgentTask(agentType, 'contextual_assistance', {
+      //   message: userMessage,
+      //   workspace: context.workspace,
+      //   leadContext: context.currentLead,
+      //   callContext: context.isCallActive ? { duration: context.callDuration } : null,
+      //   emailContext: context.emailContext,
+      //   smsContext: context.smsContext
+      // });
+
+      // if (result && result.status === 'completed') {
+      //   const aiResponse = result.output?.response || "I'm here to help! Could you be more specific about what you need?";
+
+      //   setConversation(prev => [...prev, {
+      //     role: 'assistant',
+      //     content: aiResponse,
+      //     timestamp: new Date(),
+      //     source: result.agentType
+      //   }]);
+      // } else {
+      //   throw new Error('Agent response failed');
+      // }
+
+      setConversation(prev => [...prev, {
+        role: 'assistant',
+        content: "AI assistance disabled in safe mode.",
+        timestamp: new Date(),
+        source: 'disabled'
+      }]);
     } catch (error) {
       // Fallback response
       setConversation(prev => [...prev, {

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -1,13 +1,21 @@
-export default function AuthPageFallback() {
+import React, { useEffect } from 'react';
+
+export default function Auth() {
+  useEffect(() => {
+    console.log('🔐 Auth page loaded');
+  }, []);
+
   return (
-    <div>
-      <h1>🔐 Login</h1>
-      <button onClick={mockLogin}>Login (simulate)</button>
+    <div style={{ padding: '2rem', fontSize: '1.2rem' }}>
+      <h1>🔑 AUTH PAGE</h1>
+      <button
+        onClick={() => {
+          localStorage.setItem('demo-auth', 'true');
+          window.location.href = '/safe-dashboard';
+        }}
+      >
+        Simulate Login
+      </button>
     </div>
   );
-}
-
-function mockLogin() {
-  localStorage.setItem('demo-auth', 'true');
-  window.location.href = '/sales-dashboard';
 }

--- a/src/pages/safe-dashboard.tsx
+++ b/src/pages/safe-dashboard.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+
+export default function SafeDash() {
+  useEffect(() => {
+    console.log('✅ SAFE DASHBOARD LOADED');
+  }, []);
+
+  return (
+    <div style={{ padding: '2rem', fontSize: '1.2rem' }}>
+      <h1>✅ SAFE DASHBOARD</h1>
+      <p>This dashboard has NO AI logic, NO agent code, NO crashing hooks.</p>
+      <button
+        onClick={() => {
+          localStorage.clear();
+          window.location.href = '/auth';
+        }}
+      >
+        Logout
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simplified auth and dashboard pages
- disable AI imports and calls in ManagerAI panel, AI assistant, and context-aware bubble
- replace App with minimal router and localStorage session check

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68652fd4ad1c832893f48c659f34516f