### PR TITLE
Add safe fallback Sales Dashboard

### DIFF
--- a/src/pages/sales-dashboard.tsx
+++ b/src/pages/sales-dashboard.tsx
@@ -1,3 +1,23 @@
-export default function SalesDash() {
-  return <div>✅ Sales Dashboard (safe fallback) loaded</div>;
+import { useEffect } from "react";
+
+export default function SalesDashboardSafe() {
+  useEffect(() => {
+    console.log("\uD83E\uDDEA Sales Dashboard Safe loaded");
+  }, []);
+
+  return (
+    <div style={{ padding: "2rem", fontSize: "1.2rem", fontFamily: "sans-serif" }}>
+      <h1>\uD83D\uDCCA SALES DASHBOARD (SAFE MODE)</h1>
+      <p>Currently running in non-AI mode to verify layout and auth flow stability.</p>
+      <button
+        style={{ marginTop: "1rem", padding: "0.5rem 1rem", fontSize: "1rem" }}
+        onClick={() => {
+          localStorage.clear();
+          window.location.href = "/auth";
+        }}
+      >
+        Logout
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- implement a Safe Fallback version of Sales Dashboard

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68653282b4d88328bebd1e1d8fcb0cdf