### PR TITLE
Restore full sales dashboard routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import Auth from './pages/auth';
-import SafeDash from './pages/safe-dashboard';
+import SalesDash from './pages/sales-dashboard';
 
 export default function App() {
   useEffect(() => {
@@ -20,8 +20,8 @@ export default function App() {
     <Router>
       <Routes>
         <Route path="/auth" element={<Auth />} />
-        <Route path="/safe-dashboard" element={<SafeDash />} />
-        <Route path="/*" element={<Navigate to="/safe-dashboard" replace />} />
+        <Route path="/sales-dashboard" element={<SalesDash />} />
+        <Route path="/*" element={<Navigate to="/sales-dashboard" replace />} />
       </Routes>
     </Router>
   );

--- a/src/components/Sales/SalesDashboard.tsx
+++ b/src/components/Sales/SalesDashboard.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/pages/sales/Dashboard";

--- a/src/pages/auth.tsx
+++ b/src/pages/auth.tsx
@@ -11,7 +11,7 @@ export default function Auth() {
       <button
         onClick={() => {
           localStorage.setItem('demo-auth', 'true');
-          window.location.href = '/safe-dashboard';
+          window.location.href = '/sales-dashboard';
         }}
       >
         Simulate Login

--- a/src/pages/sales-dashboard.tsx
+++ b/src/pages/sales-dashboard.tsx
@@ -1,23 +1,10 @@
-import { useEffect } from "react";
+import dynamic from "next/dynamic";
 
-export default function SalesDashboardSafe() {
-  useEffect(() => {
-    console.log("\uD83E\uDDEA Sales Dashboard Safe loaded");
-  }, []);
+const FullDashboard = dynamic(() => import("@/components/Sales/SalesDashboard"), {
+  ssr: false,
+  loading: () => <p>Loading full dashboard logic...</p>,
+});
 
-  return (
-    <div style={{ padding: "2rem", fontSize: "1.2rem", fontFamily: "sans-serif" }}>
-      <h1>\uD83D\uDCCA SALES DASHBOARD (SAFE MODE)</h1>
-      <p>Currently running in non-AI mode to verify layout and auth flow stability.</p>
-      <button
-        style={{ marginTop: "1rem", padding: "0.5rem 1rem", fontSize: "1rem" }}
-        onClick={() => {
-          localStorage.clear();
-          window.location.href = "/auth";
-        }}
-      >
-        Logout
-      </button>
-    </div>
-  );
+export default function SalesDashboardWrapper() {
+  return <FullDashboard />;
 }


### PR DESCRIPTION
## Summary
- redirect to sales dashboard after login
- update router to show sales dashboard
- dynamic load the full Sales dashboard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686538886234832892fe7ea3514cc9a4