### PR TITLE
Fix logout cleanup and demo login

### DIFF
--- a/src/contexts/auth/AuthProvider.tsx
+++ b/src/contexts/auth/AuthProvider.tsx
@@ -160,7 +160,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const signOut = async () => {
     try {
       setLoading(true);
-      
+
       const { error } = await supabase.auth.signOut();
       
       if (error) {
@@ -168,10 +168,14 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         return { error };
       }
 
-      // Clear state immediately
+      // Clear state and storage immediately
       setUser(null);
       setSession(null);
       setProfile(null);
+      if (typeof window !== 'undefined') {
+        localStorage.clear();
+        sessionStorage.clear();
+      }
       
       logger.info('Sign out successful', {}, 'auth');
       return { error: null };

--- a/src/pages/auth/AuthPage.tsx
+++ b/src/pages/auth/AuthPage.tsx
@@ -177,12 +177,6 @@ const AuthPage: React.FC = () => {
         : '/sales/dashboard';
       navigate(destination, { replace: true });
       // Don't set isSubmitting to false here - let the redirect handle it
-      
-      console.log('Demo login successful for role:', role);
-
-      // Explicitly route based on the demo user's role
-      const destination = role === 'manager' ? '/manager/dashboard' : '/sales/dashboard';
-      navigate(destination, { replace: true });
     } catch (error) {
       console.error('Demo login exception:', error);
       setAuthError('An unexpected error occurred during demo login.');


### PR DESCRIPTION
## Summary
- clear browser storage in `signOut`
- remove duplicate redirect logic in demo login handler

## Testing
- `npm test` *(fails: No "AuthProvider" export is defined)*

------
https://chatgpt.com/codex/tasks/task_e_686f1ca37b5883289f2dc2f6bcb5310e