### PR TITLE
Fix auth page loading and adjust tests

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,6 @@
 const CACHE_NAME = 'salesos-v1';
 const STATIC_CACHE_URLS = [
   '/',
-  '/auth',
   '/manifest.json'
 ];
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,4 @@
+import React from 'react'
 import { vi } from 'vitest'
 
 // Prevent real network calls to Supabase
@@ -29,5 +30,6 @@ vi.mock('@/integrations/supabase/client', () => {
 
 // Basic auth context mock so pages can render
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ profile: { id: '1', role: 'developer' } })
+  useAuth: () => ({ profile: { id: '1', role: 'developer' } }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => React.createElement(React.Fragment, null, children)
 }))


### PR DESCRIPTION
## Summary
- improve service worker cache handling by removing `/auth`
- fix tests setup so `AuthProvider` is mocked

## Testing
- `npx vitest run` *(fails: TestingLibraryElementError)*

------
https://chatgpt.com/codex/tasks/task_e_686f27eaf3e883288b43ed93e9985ce1